### PR TITLE
refactor: remove web3 wallet connection requirement

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter as Router, HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useCallback } from 'react';
-import { useChainId } from 'wagmi';
 
 // Detect if we're running on GitHub Pages and get the correct basename
 function getBasename(): string {
@@ -23,9 +22,7 @@ import Footer from './components/common/Footer';
 import NotificationDisplay from './components/common/NotificationDisplay';
 import ErrorBoundary from './components/common/ErrorBoundary';
 import './styles/styles.css';
-import './styles/rainbowkit.css';
 import { useAppReady, useOnAppReady } from './hooks/useAppReady';
-import { useWagmiConnection } from './hooks/useWagmiConnection';
 import Loading from './components/common/Loading';
 import {
   LazyHome,
@@ -42,7 +39,6 @@ import {
 } from './components/LazyComponents';
 import { NotificationProvider } from './context/NotificationContext';
 import { SettingsProvider, useTheme } from './context/SettingsContext';
-import { darkTheme, lightTheme, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 
 // Detect GH Pages once
 const isGhPages = typeof window !== 'undefined' && window.location.hostname.includes('github.io');
@@ -55,41 +51,36 @@ function AppContent() {
   useOnAppReady(onAppReadyCallback);
 
   const { fullyReady } = useAppReady();
-  const { showConnectWallet, showLoading } = useWagmiConnection();
   const { isDarkMode } = useTheme(); // Now this is inside ThemeProvider
   
   return (
-    <RainbowKitProvider theme={isDarkMode ? darkTheme() : lightTheme()}>
-      <>
-        {(!fullyReady || showLoading) ? (
-            <Loading />
-          ) : showConnectWallet ? (
-            <LazyConnectWallet />
-          ) : (
-          <div className="app-content">
-            <Navbar />
-            <NotificationDisplay />
-            <Routes>
-              <Route path="/" element={<LazyHome />} />
-              <Route path="settings" element={<LazySettings />} />
-              <Route path="devtools" element={<LazyDevTools />} />
-              <Route path=":chainId" element={<LazyChain />} />
-              <Route path=":chainId/blocks" element={<LazyBlocks />} />
-              <Route path=":chainId/block/:filter" element={<LazyBlock />} />
-              <Route path=":chainId/txs" element={<LazyTxs />} />
-              <Route path=":chainId/tx/:filter" element={<LazyTx />} />
-              <Route path=":chainId/address/:address" element={<LazyAddress />} />
-              <Route path=":chainId/mempool" element={<LazyMempool />} />
-              <Route path=":chainId/mempool/:filter" element={<LazyTx />} />
+    <>
+      {!fullyReady ? (
+          <Loading />
+        ) : (
+        <div className="app-content">
+          <Navbar />
+          <NotificationDisplay />
+          <Routes>
+            <Route path="/" element={<LazyHome />} />
+            <Route path="settings" element={<LazySettings />} />
+            <Route path=":chainId" element={<LazyChain />} />
+            <Route path=":chainId/blocks" element={<LazyBlocks />} />
+            <Route path=":chainId/block/:filter" element={<LazyBlock />} />
+            <Route path=":chainId/txs" element={<LazyTxs />} />
+            <Route path=":chainId/tx/:filter" element={<LazyTx />} />
+            <Route path=":chainId/address/:address" element={<LazyAddress />} />
+            <Route path=":chainId/mempool" element={<LazyMempool />} />
+            <Route path=":chainId/mempool/:filter" element={<LazyTx />} />
+            <Route path="devtools" element={<LazyDevTools />} />
 
-              <Route path="*" element={<Navigate to="/" replace />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
 
-            </Routes>
-            <Footer />
-          </div>
-        )}
-      </>
-    </RainbowKitProvider>
+          </Routes>
+          <Footer />
+        </div>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
- Remove wagmi and RainbowKit dependencies from App.tsx
- Remove wallet connection check that blocked app access
- Simplify loading logic to only check app ready state
- Remove useWagmiConnection hook usage
- Remove rainbowkit.css import
- Remove LazyConnectWallet conditional rendering

The app now loads directly without requiring any wallet connection, making it fully accessible as a blockchain explorer without web3 authentication.