### PR TITLE
Normalize block number handling across adapters

### DIFF
--- a/src/services/adapters/BNBAdapter/BNBAdapter.ts
+++ b/src/services/adapters/BNBAdapter/BNBAdapter.ts
@@ -15,6 +15,7 @@ import {
   hexToNumber,
 } from "./utils";
 import { extractData } from "../shared/extractData";
+import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import type { BNBClient } from "explorer-network-connectors";
 
 /**
@@ -31,7 +32,8 @@ export class BNBAdapter extends NetworkAdapter {
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
-    const result = await this.client.getBlockByNumber(blockNumber as string);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -49,7 +51,8 @@ export class BNBAdapter extends NetworkAdapter {
   async getBlockWithTransactions(
     blockNumber: BlockNumberOrTag,
   ): Promise<Block & { transactionDetails: Transaction[] }> {
-    const result = await this.client.getBlockByNumber(blockNumber as string, true);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber, true);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -188,7 +191,7 @@ export class BNBAdapter extends NetworkAdapter {
     for (let i = 0; i < count; i++) {
       const blockNum = latestBlockNumber - i;
       if (blockNum >= 0) {
-        promises.push(this.getBlock(`0x${blockNum.toString(16)}`));
+        promises.push(this.getBlock(blockNum));
       }
     }
 
@@ -218,7 +221,7 @@ export class BNBAdapter extends NetworkAdapter {
       if (blockNum < 0) break;
 
       try {
-        const blockWithTxs = await this.getBlockWithTransactions(`0x${blockNum.toString(16)}`);
+        const blockWithTxs = await this.getBlockWithTransactions(blockNum);
         for (const tx of blockWithTxs.transactionDetails) {
           transactions.push({
             ...tx,

--- a/src/services/adapters/BaseAdapter/BaseAdapter.ts
+++ b/src/services/adapters/BaseAdapter/BaseAdapter.ts
@@ -14,6 +14,7 @@ import {
   hexToNumber,
 } from "./utils";
 import { extractData } from "../shared/extractData";
+import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import type { BaseClient } from "explorer-network-connectors";
 
 /**
@@ -30,7 +31,8 @@ export class BaseAdapter extends NetworkAdapter {
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
-    const result = await this.client.getBlockByNumber(blockNumber as string);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -48,7 +50,8 @@ export class BaseAdapter extends NetworkAdapter {
   async getBlockWithTransactions(
     blockNumber: BlockNumberOrTag,
   ): Promise<Block & { transactionDetails: Transaction[] }> {
-    const result = await this.client.getBlockByNumber(blockNumber as string, true);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber, true);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -187,7 +190,7 @@ export class BaseAdapter extends NetworkAdapter {
     for (let i = 0; i < count; i++) {
       const blockNum = latestBlockNumber - i;
       if (blockNum >= 0) {
-        promises.push(this.getBlock(`0x${blockNum.toString(16)}`));
+        promises.push(this.getBlock(blockNum));
       }
     }
 
@@ -217,7 +220,7 @@ export class BaseAdapter extends NetworkAdapter {
       if (blockNum < 0) break;
 
       try {
-        const blockWithTxs = await this.getBlockWithTransactions(`0x${blockNum.toString(16)}`);
+        const blockWithTxs = await this.getBlockWithTransactions(blockNum);
         for (const tx of blockWithTxs.transactionDetails) {
           transactions.push({
             ...tx,

--- a/src/services/adapters/NetworkAdapter.ts
+++ b/src/services/adapters/NetworkAdapter.ts
@@ -9,8 +9,7 @@ import type {
 } from "../../types";
 
 export type BlockTag = "latest" | "earliest" | "pending" | "finalized" | "safe";
-// <TODO> Remove string and 0x{string} overlap
-export type BlockNumberOrTag = string | number | `0x${string}` | BlockTag;
+export type BlockNumberOrTag = number | string | BlockTag;
 
 export interface TraceLog {
   pc: number;
@@ -52,18 +51,18 @@ export abstract class NetworkAdapter {
   }
   /**
    * Get block by number or tag
-   * @param blockNumber - Block number or "latest"
+   * @param blockNumber - Block number (as number or hex string) or block tag
    * @returns Block data with optional metadata
    */
-  abstract getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>>;
+  abstract getBlock(blockNumber: number | BlockNumberOrTag): Promise<DataWithMetadata<Block>>;
 
   /**
    * Get block with full transaction details
-   * @param blockNumber - Block number or "latest"
+   * @param blockNumber - Block number (as number or hex string) or block tag
    * @returns Block with embedded transaction objects
    */
   abstract getBlockWithTransactions(
-    blockNumber: BlockNumberOrTag,
+    blockNumber: number | BlockNumberOrTag,
   ): Promise<Block & { transactionDetails: Transaction[] }>;
 
   /**

--- a/src/services/adapters/OptimismAdapter/OptimismAdapter.ts
+++ b/src/services/adapters/OptimismAdapter/OptimismAdapter.ts
@@ -14,6 +14,7 @@ import {
   hexToNumber,
 } from "./utils";
 import { extractData } from "../shared/extractData";
+import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import type { OptimismClient } from "explorer-network-connectors";
 
 /**
@@ -30,7 +31,8 @@ export class OptimismAdapter extends NetworkAdapter {
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
-    const result = await this.client.getBlockByNumber(blockNumber as string);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -48,7 +50,8 @@ export class OptimismAdapter extends NetworkAdapter {
   async getBlockWithTransactions(
     blockNumber: BlockNumberOrTag,
   ): Promise<Block & { transactionDetails: Transaction[] }> {
-    const result = await this.client.getBlockByNumber(blockNumber as string, true);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber, true);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -187,7 +190,7 @@ export class OptimismAdapter extends NetworkAdapter {
     for (let i = 0; i < count; i++) {
       const blockNum = latestBlockNumber - i;
       if (blockNum >= 0) {
-        promises.push(this.getBlock(`0x${blockNum.toString(16)}`));
+        promises.push(this.getBlock(blockNum));
       }
     }
 
@@ -217,7 +220,7 @@ export class OptimismAdapter extends NetworkAdapter {
       if (blockNum < 0) break;
 
       try {
-        const blockWithTxs = await this.getBlockWithTransactions(`0x${blockNum.toString(16)}`);
+        const blockWithTxs = await this.getBlockWithTransactions(blockNum);
         for (const tx of blockWithTxs.transactionDetails) {
           transactions.push({
             ...tx,

--- a/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
+++ b/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
@@ -15,6 +15,7 @@ import {
   hexToNumber,
 } from "./utils";
 import { extractData } from "../shared/extractData";
+import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import type { PolygonClient, SupportedChainId } from "explorer-network-connectors";
 
 /**
@@ -29,7 +30,8 @@ export class PolygonAdapter extends NetworkAdapter {
     this.client = client;
   }
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
-    const result = await this.client.getBlockByNumber(blockNumber as string);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -47,7 +49,8 @@ export class PolygonAdapter extends NetworkAdapter {
   async getBlockWithTransactions(
     blockNumber: BlockNumberOrTag,
   ): Promise<Block & { transactionDetails: Transaction[] }> {
-    const result = await this.client.getBlockByNumber(blockNumber as string, true);
+    const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
+    const result = await this.client.getBlockByNumber(normalizedBlockNumber, true);
 
     const blockData = extractData<typeof result.data>(result.data);
     if (!blockData) {
@@ -186,7 +189,7 @@ export class PolygonAdapter extends NetworkAdapter {
     for (let i = 0; i < count; i++) {
       const blockNum = latestBlockNumber - i;
       if (blockNum >= 0) {
-        promises.push(this.getBlock(`0x${blockNum.toString(16)}`));
+        promises.push(this.getBlock(blockNum));
       }
     }
 
@@ -216,7 +219,7 @@ export class PolygonAdapter extends NetworkAdapter {
       if (blockNum < 0) break;
 
       try {
-        const blockWithTxs = await this.getBlockWithTransactions(`0x${blockNum.toString(16)}`);
+        const blockWithTxs = await this.getBlockWithTransactions(blockNum);
         for (const tx of blockWithTxs.transactionDetails) {
           transactions.push({
             ...tx,

--- a/src/services/adapters/shared/normalizeBlockNumber.ts
+++ b/src/services/adapters/shared/normalizeBlockNumber.ts
@@ -1,0 +1,15 @@
+import type { BlockNumberOrTag } from "../NetworkAdapter";
+
+/**
+ * Normalizes a block number to the format expected by RPC clients
+ * Converts numeric block numbers to hex strings, passes through block tags and hex strings unchanged
+ *
+ * @param blockNumber - Block number as number, hex string, or block tag
+ * @returns Block number as hex string or block tag
+ */
+export function normalizeBlockNumber(blockNumber: BlockNumberOrTag): `0x${string}` | string {
+  if (typeof blockNumber === "number") {
+    return `0x${blockNumber.toString(16)}`;
+  }
+  return blockNumber;
+}


### PR DESCRIPTION
Add block number normalization to accept both numeric and hex string inputs
across all network adapters, eliminating the need for manual conversion at
the UI layer.

## Changes
- Update BlockNumberOrTag type to include number | string | BlockTag
- Create normalizeBlockNumber utility function in shared adapters
- Update all adapters (Arbitrum, EVM, Optimism, Base, BNB, Polygon) to:
  - Use normalizeBlockNumber in getBlock and getBlockWithTransactions
  - Accept plain numbers instead of requiring hex strings
  - Simplify internal method calls by passing numbers directly

This improves the developer experience by allowing components to pass
block numbers as plain numbers (e.g., 12345) instead of requiring manual
hex conversion (e.g., "0x3039").