### PR TITLE
refactor: use local networks.json instead of fetching from metadata

### DIFF
--- a/src/config/networks.json
+++ b/src/config/networks.json
@@ -1,0 +1,278 @@
+{
+  "updatedAt": "2025-12-11T12:01:22.402Z",
+  "count": 8,
+  "networks": [
+    {
+      "chainId": 1,
+      "name": "Ethereum Mainnet",
+      "shortName": "Ethereum",
+      "description": "The main Ethereum network - the original smart contract platform",
+      "currency": "ETH",
+      "color": "#627EEA",
+      "isTestnet": false,
+      "subscription": {
+        "tier": 1,
+        "expiresAt": "2099-12-31"
+      },
+      "logo": "assets/networks/1.svg",
+      "profile": "profiles/networks/1.md",
+      "rpc": {
+        "public": [
+          "https://eth.llamarpc.com",
+          "https://rpc.ankr.com/eth",
+          "https://ethereum.publicnode.com"
+        ]
+      },
+      "links": [
+        {
+          "name": "Website",
+          "url": "https://ethereum.org",
+          "description": "Official Ethereum website"
+        },
+        {
+          "name": "Docs",
+          "url": "https://ethereum.org/developers",
+          "description": "Developer documentation"
+        },
+        {
+          "name": "GitHub",
+          "url": "https://github.com/ethereum",
+          "description": "Ethereum GitHub organization"
+        }
+      ]
+    },
+    {
+      "chainId": 8453,
+      "name": "Base",
+      "shortName": "Base",
+      "description": "Ethereum Layer 2 built on the OP Stack by Coinbase",
+      "currency": "ETH",
+      "color": "#0052FF",
+      "isTestnet": false,
+      "logo": "assets/networks/8453.svg",
+      "rpc": {
+        "public": [
+          "https://mainnet.base.org",
+          "https://base.publicnode.com",
+          "https://rpc.ankr.com/base"
+        ]
+      },
+      "links": [
+        {
+          "name": "Website",
+          "url": "https://base.org",
+          "description": "Official Base website"
+        },
+        {
+          "name": "Bridge",
+          "url": "https://bridge.base.org",
+          "description": "Bridge assets to Base"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.base.org",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "chainId": 42161,
+      "name": "Arbitrum One",
+      "shortName": "Arbitrum",
+      "description": "Ethereum Layer 2 scaling solution using optimistic rollups",
+      "currency": "ETH",
+      "color": "#28A0F0",
+      "isTestnet": false,
+      "logo": "assets/networks/42161.svg",
+      "rpc": {
+        "public": [
+          "https://arb1.arbitrum.io/rpc",
+          "https://rpc.ankr.com/arbitrum",
+          "https://arbitrum.publicnode.com"
+        ]
+      },
+      "links": [
+        {
+          "name": "Website",
+          "url": "https://arbitrum.io",
+          "description": "Official Arbitrum website"
+        },
+        {
+          "name": "Bridge",
+          "url": "https://bridge.arbitrum.io",
+          "description": "Official Arbitrum bridge"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.arbitrum.io",
+          "description": "Developer documentation"
+        },
+        {
+          "name": "GitHub",
+          "url": "https://github.com/OffchainLabs",
+          "description": "Offchain Labs GitHub"
+        }
+      ]
+    },
+    {
+      "chainId": 10,
+      "name": "Optimism",
+      "shortName": "Optimism",
+      "description": "Ethereum Layer 2 scaling solution using optimistic rollups",
+      "currency": "ETH",
+      "color": "#FF0420",
+      "isTestnet": false,
+      "logo": "assets/networks/10.svg",
+      "rpc": {
+        "public": [
+          "https://mainnet.optimism.io",
+          "https://optimism.publicnode.com",
+          "https://rpc.ankr.com/optimism"
+        ]
+      },
+      "links": [
+        {
+          "name": "Website",
+          "url": "https://optimism.io",
+          "description": "Official Optimism website"
+        },
+        {
+          "name": "Bridge",
+          "url": "https://app.optimism.io/bridge",
+          "description": "Bridge assets to Optimism"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.optimism.io",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "chainId": 56,
+      "name": "BNB Smart Chain",
+      "shortName": "BSC",
+      "description": "EVM-compatible blockchain by Binance",
+      "currency": "BNB",
+      "color": "#F0B90B",
+      "isTestnet": false,
+      "logo": "assets/networks/56.svg",
+      "rpc": {
+        "public": [
+          "https://bsc-dataseed.binance.org",
+          "https://bsc.publicnode.com",
+          "https://rpc.ankr.com/bsc"
+        ]
+      },
+      "links": [
+        {
+          "name": "Website",
+          "url": "https://www.bnbchain.org",
+          "description": "Official BNB Chain website"
+        },
+        {
+          "name": "Bridge",
+          "url": "https://www.bnbchain.org/bridge",
+          "description": "Bridge assets"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.bnbchain.org",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "chainId": 137,
+      "name": "Polygon",
+      "shortName": "Polygon",
+      "description": "Ethereum sidechain with fast and low-cost transactions",
+      "currency": "POL",
+      "color": "#8247E5",
+      "isTestnet": false,
+      "logo": "assets/networks/137.svg",
+      "rpc": {
+        "public": [
+          "https://polygon-rpc.com",
+          "https://polygon-bor.publicnode.com",
+          "https://rpc.ankr.com/polygon"
+        ]
+      },
+      "links": [
+        {
+          "name": "Website",
+          "url": "https://polygon.technology",
+          "description": "Official Polygon website"
+        },
+        {
+          "name": "Bridge",
+          "url": "https://portal.polygon.technology/bridge",
+          "description": "Bridge assets to Polygon"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.polygon.technology",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "chainId": 11155111,
+      "name": "Ethereum Sepolia",
+      "shortName": "Sepolia",
+      "description": "Ethereum testnet for developers",
+      "currency": "ETH",
+      "color": "#CFB5F0",
+      "isTestnet": true,
+      "logo": "assets/networks/11155111.svg",
+      "rpc": {
+        "public": [
+          "https://rpc.sepolia.org",
+          "https://ethereum-sepolia.publicnode.com",
+          "https://rpc.ankr.com/eth_sepolia"
+        ]
+      },
+      "links": [
+        {
+          "name": "Faucet",
+          "url": "https://sepoliafaucet.com",
+          "description": "Get testnet ETH"
+        },
+        {
+          "name": "Docs",
+          "url": "https://ethereum.org/developers",
+          "description": "Ethereum developer docs"
+        }
+      ]
+    },
+    {
+      "chainId": 97,
+      "name": "BNB Smart Chain Testnet",
+      "shortName": "BSC Testnet",
+      "description": "BNB Smart Chain testnet for developers",
+      "currency": "tBNB",
+      "color": "#F0B90B",
+      "isTestnet": true,
+      "logo": "assets/networks/97.svg",
+      "rpc": {
+        "public": [
+          "https://data-seed-prebsc-1-s1.binance.org:8545",
+          "https://bsc-testnet.publicnode.com",
+          "https://rpc.ankr.com/bsc_testnet_chapel"
+        ]
+      },
+      "links": [
+        {
+          "name": "Faucet",
+          "url": "https://testnet.bnbchain.org/faucet-smart",
+          "description": "Get testnet BNB"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.bnbchain.org",
+          "description": "Developer documentation"
+        }
+      ]
+    }
+  ]
+}

--- a/src/services/MetadataService.ts
+++ b/src/services/MetadataService.ts
@@ -1,6 +1,9 @@
 /**
  * Service for fetching metadata from the openscan-explorer/explorer-metadata repository
+ * Note: Networks are now loaded from a local JSON file instead of being fetched
  */
+
+import networksData from "../config/networks.json";
 
 const METADATA_BASE_URL =
   "https://raw.githubusercontent.com/openscan-explorer/explorer-metadata/main/dist";
@@ -45,46 +48,17 @@ export interface NetworksResponse {
   networks: NetworkMetadata[];
 }
 
-// Cache for fetched data
-let networksCache: NetworksResponse | null = null;
-let networksCacheTime: number = 0;
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
 
 /**
- * Fetch network configurations from the metadata repository
+ * Get network configurations from the local JSON file
+ * Previously fetched from metadata repository, now bundled locally
  */
 export async function fetchNetworks(): Promise<NetworksResponse> {
-  const now = Date.now();
-
-  // Return cached data if still valid
-  if (networksCache && now - networksCacheTime < CACHE_DURATION) {
-    return networksCache;
-  }
-
-  try {
-    const response = await fetch(`${METADATA_BASE_URL}/networks.json`);
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch networks: ${response.statusText}`);
-    }
-
-    const data: NetworksResponse = await response.json();
-
-    // Update cache
-    networksCache = data;
-    networksCacheTime = now;
-
-    return data;
-  } catch (error) {
-    console.error("Error fetching networks from metadata:", error);
-
-    // Return cached data if available, even if stale
-    if (networksCache) {
-      return networksCache;
-    }
-
-    throw error;
-  }
+  return {
+    updatedAt: networksData.updatedAt,
+    networks: networksData.networks as NetworkMetadata[],
+  };
 }
 
 /**
@@ -95,14 +69,6 @@ export function getNetworkLogoUrl(logoPath: string): string {
     return logoPath;
   }
   return `${METADATA_BASE_URL}/${logoPath}`;
-}
-
-/**
- * Clear the networks cache (useful for testing or forced refresh)
- */
-export function clearNetworksCache(): void {
-  networksCache = null;
-  networksCacheTime = 0;
 }
 
 /**


### PR DESCRIPTION
- Add networks.json with bundled network configurations
- Update networks.ts to import from local JSON file
- Update MetadataService.ts fetchNetworks to return local data
- Remove clearNetworksCache function (no longer needed)