### PR TITLE
Fix navbar dropdown redirect on Github Pages

### DIFF
--- a/src/components/navbar/NavbarLogo.tsx
+++ b/src/components/navbar/NavbarLogo.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { NetworkConfig } from "../../config/networks";
 import { getSubdomainForNetwork, subdomainConfig } from "../../config/subdomains";
 import { useNetworks } from "../../context/AppContext";
@@ -43,6 +43,7 @@ export default function NavbarLogo() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
+  const navigate = useNavigate();
 
   // Get current subdomain info
   const subdomain = getSubdomain();
@@ -136,11 +137,11 @@ export default function NavbarLogo() {
       const targetNetworkId = networkId ?? activeNetworkId;
       if (!targetNetworkId) return;
 
-      // Navigate to network page path
-      window.location.href = `/${targetNetworkId}`;
+      // Navigate to network page path using React Router
+      navigate(`/${targetNetworkId}`);
       setIsDropdownOpen(false);
     },
-    [activeNetworkId],
+    [activeNetworkId, navigate],
   );
 
   // If not on a network subdomain, show the regular OpenScan cube


### PR DESCRIPTION
## Description

Fixed the dropdown redirect bug in NavbarLogo.tsx. The issue was that the dropdown was using `window.location.href` for navigation, which bypassed React Router's hash-based routing used on GitHub Pages.

## Related Issue

<!-- Link to the related issue (e.g., Closes #123) -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

<!-- List the main changes made in this PR -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

This change needs to be tested on GitHub pages deployment directly