### PR TITLE
Fix parallel strategy renders when first response is error

### DIFF
--- a/src/services/adapters/shared/extractData.ts
+++ b/src/services/adapters/shared/extractData.ts
@@ -13,13 +13,8 @@ export function extractData<T>(strategyResultData: T | any): T {
     const firstItem = strategyResultData[0];
 
     // Check if it has the RPCProviderResponse structure
-    if (
-      firstItem &&
-      typeof firstItem === "object" &&
-      "url" in firstItem &&
-      "status" in firstItem &&
-      "data" in firstItem
-    ) {
+    // Note: error responses may not have 'data' field, so we check for url+status
+    if (firstItem && typeof firstItem === "object" && "url" in firstItem && "status" in firstItem) {
       // Find the first successful response
       const successfulResponse = strategyResultData.find(
         // biome-ignore lint/suspicious/noExplicitAny: Provider response type is dynamic


### PR DESCRIPTION
## Description

Fix React rendering error when first RPC provider fails in parallel strategy mode. The `extractData` function now properly detects and handles error responses that don't contain a `data` field.

## Related Issue

Closes #126

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Modified `extractData` function to detect provider response arrays by checking only `url` and `status` fields instead of requiring `data` field
- This allows proper handling of error responses in parallel mode which don't have a `data` field
- Function now correctly extracts data from successful providers even when first provider fails

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

The issue occurred because error responses from RPC providers have structure `{url, status, responseTime, error}` without a `data` field. The previous check required all three fields (`url`, `status`, `data`), causing the function to return the raw array instead of extracting the actual data value. This led to React trying to render provider response objects as children, causing the error.
