### PR TITLE
Update dev with last minute fixes we did on main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Default RPC endpoints:
 
 - **React 19** - UI framework
 - **TypeScript** - Type safety
-- **React Router** - Client-side routing
+- **React Router** - Client-side routing (HashRouter for IPFS/ENS compatibility)
 - **Custom RPC Service** - Direct JSON-RPC calls to blockchain nodes
 - **Biome** – Code formatting and linting
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,8 @@
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { useCallback, useEffect } from "react";
-import {
-  HashRouter,
-  Navigate,
-  Route,
-  BrowserRouter as Router,
-  Routes,
-  useLocation,
-  useNavigate,
-} from "react-router-dom";
+import { HashRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { cssVariables, getRainbowKitTheme } from "./theme";
 import { getBaseDomainUrl, getSubdomain, getSubdomainRedirect } from "./utils/subdomainUtils";
-
-// Detect if we're running on GitHub Pages and get the correct basename
-function getBasename(): string {
-  const { hostname, pathname } = window.location;
-
-  // Check if we're on GitHub Pages
-  if (hostname.includes("github.io")) {
-    // Extract repo name from pathname (first segment after domain)
-    const pathSegments = pathname.split("/").filter(Boolean);
-    if (pathSegments.length > 0) {
-      return `/${pathSegments[0]}`;
-    }
-  }
-
-  // For local development or custom domains, no basename needed
-  return "";
-}
 
 import ErrorBoundary from "./components/common/ErrorBoundary";
 import Footer from "./components/common/Footer";
@@ -63,9 +38,6 @@ import {
 } from "./components/LazyComponents";
 import { SettingsProvider, useSettings, useTheme } from "./context/SettingsContext";
 import { useAppReady, useOnAppReady } from "./hooks/useAppReady";
-
-// Detect GH Pages once
-const isGhPages = typeof window !== "undefined" && window.location.hostname.includes("github.io");
 
 // Component that handles subdomain redirects
 function SubdomainRedirect() {
@@ -159,17 +131,13 @@ function AppContent() {
 
 // Main App component that provides the theme context
 function App() {
-  const BaseRouter = isGhPages ? HashRouter : Router;
-  // IMPORTANT: no basename for HashRouter
-  const basename = isGhPages ? "" : getBasename();
-
   return (
     <ErrorBoundary>
       <SettingsProvider>
         <RainbowKitProviderWrapper>
-          <BaseRouter basename={basename}>
+          <HashRouter>
             <AppContent />
-          </BaseRouter>
+          </HashRouter>
         </RainbowKitProviderWrapper>
       </SettingsProvider>
     </ErrorBoundary>

--- a/src/utils/subdomainUtils.ts
+++ b/src/utils/subdomainUtils.ts
@@ -18,6 +18,11 @@ export function getSubdomain(): string | null {
     return null;
   }
 
+  // Skip subdomain processing for ENS gateways (e.g., openscan.eth.link, openscan.eth.limo)
+  if (hostname.endsWith(".eth.link") || hostname.endsWith(".eth.limo")) {
+    return null;
+  }
+
   // Handle localhost subdomains (e.g., ethereum.localhost)
   if (hostname.endsWith(".localhost")) {
     return hostname.replace(".localhost", "");


### PR DESCRIPTION
## Description

This pull request updates the routing strategy to use `HashRouter` exclusively, improving compatibility with IPFS and ENS gateways, and refines subdomain handling logic to avoid unnecessary redirects for ENS-based domains. It also updates documentation to clarify the new routing approach.

Routing changes for IPFS/ENS compatibility:
* All routing now uses `HashRouter` instead of conditionally switching between `BrowserRouter` and `HashRouter`, simplifying the code and ensuring compatibility with decentralized gateways. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L3-L31) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L162-R140)
* The README has been updated to clarify that `HashRouter` is used for IPFS/ENS compatibility. (`README.md`, [README.mdL249-R249](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L249-R249))

Subdomain handling improvements:
* The subdomain utility now skips subdomain processing for ENS gateways (`.eth.link`, `.eth.limo`), preventing unnecessary redirects and ensuring correct behavior when accessed via ENS. (`src/utils/subdomainUtils.ts`, [src/utils/subdomainUtils.tsR21-R25](diffhunk://#diff-76bc5695d1ba3b1ab6541a41b5b52923280789bc986c9645696c31c0142c9627R21-R25))

Code cleanup:
* Removed legacy code for GitHub Pages detection and basename calculation, as it is no longer needed with the exclusive use of `HashRouter`. (`src/App.tsx`, [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L67-L69) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L162-R140)
