### PR TITLE
fix(webpack): add content hash to chunks and optimize dev builds

### DIFF
--- a/scripts/run-test-env.sh
+++ b/scripts/run-test-env.sh
@@ -51,6 +51,8 @@ npx hardhat compile
 echo "   Starting Hardhat node..."
 npx hardhat node --network hardhatMainnet > /tmp/hardhat-node.log 2>&1 &
 
+sleep 1
+
 # Here the network is set to localhost to target the running hardhat node via an HTTP node
 npx hardhat ignition deploy ignition/modules/TestSuite.ts --network localhost
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = {
 	entry: path.resolve(__dirname, "src", "index.tsx"),
 	output: {
 		path: path.resolve(__dirname, "dist"),
-		filename: "bundle.js",
+		filename: isProd ? "[name].[contenthash].js" : "bundle.js",
+		chunkFilename: "[name].[contenthash].bundle.js",
 		publicPath: publicPath, // key for GH Pages
 		clean: true,
 		charset: false,
@@ -74,27 +75,29 @@ module.exports = {
 	optimization: {
 		moduleIds: "deterministic",
 		chunkIds: "deterministic",
-		minimize: true,
-		minimizer: [
-			new (require("terser-webpack-plugin"))({
-				terserOptions: {
-					mangle: {
-						safari10: true,
-						reserved: [],
-					},
-					compress: {
-						drop_console: false,
-						drop_debugger: false,
-						passes: 1,
-					},
-					format: {
-						comments: false,
-					},
-				},
-				parallel: false,
-				extractComments: false,
-			}),
-		],
+		minimize: isProd,
+		minimizer: isProd
+			? [
+					new (require("terser-webpack-plugin"))({
+						terserOptions: {
+							mangle: {
+								safari10: true,
+								reserved: [],
+							},
+							compress: {
+								drop_console: false,
+								drop_debugger: false,
+								passes: 1,
+							},
+							format: {
+								comments: false,
+							},
+						},
+						parallel: false,
+						extractComments: false,
+					}),
+				]
+			: [],
 	},
 	plugins: [
 		new HtmlWebpackPlugin({


### PR DESCRIPTION
## Description

Fix browser cache conflicts when switching between different explorer builds (e.g., hardhat plugin explorer vs current version) by adding content hashes to chunk filenames.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Add `chunkFilename` with `[contenthash]` to webpack output config
- Add `[contenthash]` to production bundle filename
- Only minimize in production mode for faster dev builds
- Add sleep before ignition deploy in test env script for reliability

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

When switching between different explorer builds on the same port, the browser serves cached chunks from the old build. Since module IDs differ between builds, this causes "Cannot find module" errors. Using `[contenthash]` ensures each build produces uniquely named files - same code = same hash (deterministic), different code = different hash (no cache conflicts).