### PR TITLE
Add RPC badge to fallback strategy in all pages

### DIFF
--- a/src/services/adapters/shared/mergeMetadata.ts
+++ b/src/services/adapters/shared/mergeMetadata.ts
@@ -2,8 +2,8 @@ import type { RPCMetadata, RPCProviderResponse } from "../../../types";
 
 /**
  * Merges multiple RPCMetadata objects from sequential calls
- * Takes the intersection of providers (only providers that succeeded in ALL calls)
- * and combines the data arrays
+ * For parallel strategy: Takes the intersection of providers (only providers that succeeded in ALL calls)
+ * For fallback strategy: Returns the last metadata (merging doesn't apply)
  */
 export function mergeMetadata<T>(
   metadataList: Array<RPCMetadata | undefined>,
@@ -13,6 +13,15 @@ export function mergeMetadata<T>(
 
   if (validMetadata.length === 0) {
     return undefined;
+  }
+
+  // Check if all metadata is fallback strategy
+  const allFallback = validMetadata.every((m) => m.strategy === "fallback");
+
+  if (allFallback) {
+    // For fallback, return the last metadata since merging doesn't apply
+    // The last call's attempt history is most relevant
+    return validMetadata[validMetadata.length - 1];
   }
 
   // If only one metadata object, return it with transformed data

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -2854,6 +2854,42 @@
 	font-weight: 600;
 }
 
+/* Fallback mode styles */
+.rpc-indicator-item.fallback-mode {
+	cursor: default;
+}
+
+.rpc-indicator-item.fallback-mode:hover {
+	background: transparent;
+}
+
+.rpc-indicator-fallback-info {
+	padding: 8px 16px;
+	background: var(--overlay-light-5);
+	border-bottom: 1px solid var(--overlay-light-10);
+	font-size: 12px;
+	color: var(--text-secondary);
+}
+
+.rpc-indicator-item-time {
+	margin-top: 4px;
+	font-size: 10px;
+	color: var(--text-tertiary);
+	padding-left: 24px;
+}
+
+.rpc-indicator-footer {
+	padding: 8px 16px;
+	border-top: 1px solid var(--overlay-light-10);
+	background: var(--overlay-light-3);
+}
+
+.rpc-indicator-footer-note {
+	font-size: 10px;
+	color: var(--text-secondary);
+	font-style: italic;
+}
+
 /* Version Warning Icon */
 .build-warning-icon {
 	position: relative;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -289,10 +289,10 @@ export const DEFAULT_SETTINGS: UserSettings = {
 export type RPCStrategy = "fallback" | "parallel";
 
 /**
- * Metadata about RPC request when using parallel strategy
+ * Metadata about RPC request when using parallel or fallback strategy
  */
 export interface RPCMetadata {
-  strategy: "parallel";
+  strategy: "parallel" | "fallback";
   timestamp: number;
   responses: RPCProviderResponse[];
   hasInconsistencies: boolean;


### PR DESCRIPTION
## Description

Add the RPC indicator badge for the fallback strategy that displays a success ratio (e.g., `1/2` means the second provider succeeded) with hover details showing the provider's attempt history.

## Related Issue

Closes #140

Merge  https://github.com/openscan-explorer/network-connectors/pull/13 before
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Update `RPCMetadata` type to accept `"fallback"` strategy
- Modify the `RPCIndicator` component to handle fallback mode display
- Show attempt ratio (`1/N`) for fallback vs success count (`✓ N/M`) for parallel
- Add "Succeeded on attempt #N" info banner when multiple attempts are needed
- Display response time for each provider attempt
- Disable provider selection in fallback mode (informational only)
- Add fallback-specific CSS styles
- Update `mergeMetadata` utility to handle fallback strategy

## Screenshots (if applicable)
### Network page
<img width="804" height="664" alt="Screenshot 2026-01-16 at 11 11 17 AM" src="https://github.com/user-attachments/assets/1eeb97e0-456e-4f04-afe0-e01a6177d20a" />
<img width="804" height="664" alt="Screenshot 2026-01-16 at 11 11 24 AM" src="https://github.com/user-attachments/assets/44fc790a-1c1a-4dcb-bdfa-6c52dbf4dfc2" />
### Blocks page
<img width="1247" height="681" alt="Screenshot 2026-01-16 at 11 14 31 AM" src="https://github.com/user-attachments/assets/57f0c423-5899-4fb2-abaf-cf4be49c7e51" />
<img width="1247" height="681" alt="Screenshot 2026-01-16 at 11 14 36 AM" src="https://github.com/user-attachments/assets/e562ba5f-a270-41a2-86f4-60b179b2bc0e" />

### Block page
<img width="1247" height="681" alt="Screenshot 2026-01-16 at 12 40 52 PM" src="https://github.com/user-attachments/assets/fbf40bdd-9e45-40df-a085-5ddc4a5ad7eb" />


## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

Requires `@openscan/network-connectors` package update to return metadata from fallback strategy.