### PR TITLE
feat(settings): improve settings page UX and add API keys management

### DIFF
--- a/src/components/pages/settings/index.tsx
+++ b/src/components/pages/settings/index.tsx
@@ -3,7 +3,47 @@ import { useCallback, useContext, useMemo, useState } from "react";
 import { getEnabledNetworks } from "../../../config/networks";
 import { AppContext } from "../../../context/AppContext";
 import { useSettings } from "../../../context/SettingsContext";
+import { clearSupportersCache } from "../../../services/MetadataService";
 import type { RPCUrls, RpcUrlsContextType } from "../../../types";
+
+// Infura network slugs by chain ID
+const INFURA_NETWORKS: Record<number, string> = {
+  1: "mainnet",
+  11155111: "sepolia",
+  42161: "arbitrum-mainnet",
+  10: "optimism-mainnet",
+  137: "polygon-mainnet",
+  8453: "base-mainnet",
+};
+
+// Alchemy network slugs by chain ID
+const ALCHEMY_NETWORKS: Record<number, string> = {
+  1: "eth-mainnet",
+  11155111: "eth-sepolia",
+  42161: "arb-mainnet",
+  10: "opt-mainnet",
+  137: "polygon-mainnet",
+  8453: "base-mainnet",
+};
+
+const getInfuraUrl = (chainId: number, apiKey: string): string | null => {
+  const slug = INFURA_NETWORKS[chainId];
+  return slug ? `https://${slug}.infura.io/v3/${apiKey}` : null;
+};
+
+const getAlchemyUrl = (chainId: number, apiKey: string): string | null => {
+  const slug = ALCHEMY_NETWORKS[chainId];
+  return slug ? `https://${slug}.g.alchemy.com/v2/${apiKey}` : null;
+};
+
+const isInfuraUrl = (url: string): boolean => url.includes("infura.io");
+const isAlchemyUrl = (url: string): boolean => url.includes("alchemy.com");
+
+const getProviderBadge = (url: string): string | null => {
+  if (isInfuraUrl(url)) return "INFURA";
+  if (isAlchemyUrl(url)) return "ALCHEMY";
+  return null;
+};
 
 const Settings: React.FC = () => {
   const { rpcUrls, setRpcUrls } = useContext(AppContext);
@@ -12,12 +52,105 @@ const Settings: React.FC = () => {
     ...rpcUrls,
   });
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [cacheCleared, setCacheCleared] = useState(false);
   const [draggedItem, setDraggedItem] = useState<{ chainId: number; index: number } | null>(null);
   const [fetchingChainId, setFetchingChainId] = useState<number | null>(null);
+  const [expandedChains, setExpandedChains] = useState<Set<number>>(new Set());
+  const [localApiKeys, setLocalApiKeys] = useState({
+    infura: settings.apiKeys?.infura || "",
+    alchemy: settings.apiKeys?.alchemy || "",
+  });
+  const [showApiKeys, setShowApiKeys] = useState({
+    infura: false,
+    alchemy: false,
+  });
 
   const updateField = (key: keyof RpcUrlsContextType, value: string) => {
     setLocalRpc((prev) => ({ ...prev, [key]: value }));
   };
+
+  // Toggle chain section expand/collapse
+  const toggleChainExpanded = (chainId: number) => {
+    setExpandedChains((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(chainId)) {
+        newSet.delete(chainId);
+      } else {
+        newSet.add(chainId);
+      }
+      return newSet;
+    });
+  };
+
+  // Clear all caches
+  const clearAllCaches = useCallback(() => {
+    // Clear metadata service caches
+    clearSupportersCache();
+    // Clear localStorage caches if any
+    localStorage.removeItem("openscan_cache");
+    setCacheCleared(true);
+    setTimeout(() => setCacheCleared(false), 3000);
+  }, []);
+
+  // Clear all site data (like browser dev tools)
+  const clearSiteData = useCallback(async () => {
+    if (
+      !window.confirm(
+        "This will clear all settings, RPC configurations, API keys, and cached data. The page will reload. Continue?",
+      )
+    ) {
+      return;
+    }
+
+    // Clear localStorage and sessionStorage
+    localStorage.clear();
+    sessionStorage.clear();
+
+    // Clear all cookies for this site
+    for (const cookie of document.cookie.split(";")) {
+      const name = cookie.split("=")[0]?.trim();
+      if (name) {
+        // biome-ignore lint/suspicious/noDocumentCookie: Required to clear cookies
+        document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+      }
+    }
+
+    // Clear IndexedDB databases
+    if (window.indexedDB?.databases) {
+      try {
+        const databases = await window.indexedDB.databases();
+        for (const db of databases) {
+          if (db.name) {
+            window.indexedDB.deleteDatabase(db.name);
+          }
+        }
+      } catch (e) {
+        console.warn("Could not clear IndexedDB:", e);
+      }
+    }
+
+    // Clear Cache Storage (Service Worker caches)
+    if ("caches" in window) {
+      try {
+        const cacheNames = await caches.keys();
+        await Promise.all(cacheNames.map((name) => caches.delete(name)));
+      } catch (e) {
+        console.warn("Could not clear Cache Storage:", e);
+      }
+    }
+
+    // Unregister service workers
+    if ("serviceWorker" in navigator) {
+      try {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((reg) => reg.unregister()));
+      } catch (e) {
+        console.warn("Could not unregister service workers:", e);
+      }
+    }
+
+    window.location.reload();
+  }, []);
 
   // Helper to get URLs as array from localRpc
   const getLocalRpcArray = (chainId: number): string[] => {
@@ -156,7 +289,7 @@ const Settings: React.FC = () => {
         const arr = val
           .split(",")
           .map((s) => s.trim())
-          .filter(Boolean); // Previene errores por multiples comas (,,,)
+          .filter(Boolean);
         // biome-ignore lint/suspicious/noExplicitAny: <TODO>
         (acc as any)[k] = arr;
       } else {
@@ -165,6 +298,65 @@ const Settings: React.FC = () => {
       }
       return acc;
     }, {} as RpcUrlsContextType);
+
+    // Get previous API keys from settings
+    const prevInfuraKey = settings.apiKeys?.infura || "";
+    const prevAlchemyKey = settings.apiKeys?.alchemy || "";
+
+    // Process each chain to add/remove provider URLs
+    for (const chainId of Object.keys(INFURA_NETWORKS).map(Number)) {
+      const key = chainId as unknown as keyof RpcUrlsContextType;
+      // biome-ignore lint/suspicious/noExplicitAny: <TODO>
+      let urls: string[] = (parsed as any)[key] || [];
+
+      // Handle Infura
+      const oldInfuraUrl = prevInfuraKey ? getInfuraUrl(chainId, prevInfuraKey) : null;
+      const newInfuraUrl = localApiKeys.infura ? getInfuraUrl(chainId, localApiKeys.infura) : null;
+
+      // Remove old Infura URL if key changed or removed
+      if (oldInfuraUrl && oldInfuraUrl !== newInfuraUrl) {
+        urls = urls.filter((u) => u !== oldInfuraUrl);
+      }
+      // Add new Infura URL if key added and not already present
+      if (newInfuraUrl && !urls.includes(newInfuraUrl)) {
+        urls = [newInfuraUrl, ...urls];
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: <TODO>
+      (parsed as any)[key] = urls;
+    }
+
+    for (const chainId of Object.keys(ALCHEMY_NETWORKS).map(Number)) {
+      const key = chainId as unknown as keyof RpcUrlsContextType;
+      // biome-ignore lint/suspicious/noExplicitAny: <TODO>
+      let urls: string[] = (parsed as any)[key] || [];
+
+      // Handle Alchemy
+      const oldAlchemyUrl = prevAlchemyKey ? getAlchemyUrl(chainId, prevAlchemyKey) : null;
+      const newAlchemyUrl = localApiKeys.alchemy
+        ? getAlchemyUrl(chainId, localApiKeys.alchemy)
+        : null;
+
+      // Remove old Alchemy URL if key changed or removed
+      if (oldAlchemyUrl && oldAlchemyUrl !== newAlchemyUrl) {
+        urls = urls.filter((u) => u !== oldAlchemyUrl);
+      }
+      // Add new Alchemy URL if key added and not already present
+      if (newAlchemyUrl && !urls.includes(newAlchemyUrl)) {
+        urls = [newAlchemyUrl, ...urls];
+      }
+
+      // biome-ignore lint/suspicious/noExplicitAny: <TODO>
+      (parsed as any)[key] = urls;
+    }
+
+    // Save API keys to settings
+    updateSettings({
+      apiKeys: {
+        infura: localApiKeys.infura || undefined,
+        alchemy: localApiKeys.alchemy || undefined,
+      },
+    });
 
     setRpcUrls(parsed);
     setSaveSuccess(true);
@@ -180,208 +372,365 @@ const Settings: React.FC = () => {
   }, []);
 
   return (
-    <div className="container-medium page-container-padded">
-      <div className="page-card settings-container">
-        <h1 className="page-title-small">Settings</h1>
-
-        {/* Success Message */}
-        {saveSuccess && (
-          <div className="settings-success-message">✓ Settings saved successfully!</div>
-        )}
-
-        {/* Top Row: Appearance and RPC Strategy side by side */}
-        <div className="settings-top-row">
-          {/* Appearance Settings Section */}
-          <div className="settings-section no-margin">
-            <h2 className="settings-section-title">🎨 Appearance</h2>
-            <p className="settings-section-description">
-              Customize the visual appearance of the application.
-            </p>
-
-            <div className="settings-item">
-              <div>
-                <div className="settings-item-label">Funny Background Blocks</div>
-                <div className="settings-item-description">
-                  Show animated isometric blocks in the background
-                </div>
-              </div>
-              <label className="settings-toggle">
-                <input
-                  type="checkbox"
-                  checked={settings.showBackgroundBlocks ?? true}
-                  onChange={(e) => updateSettings({ showBackgroundBlocks: e.target.checked })}
-                  className="settings-toggle-input"
-                />
-                <span
-                  className={`settings-toggle-slider ${settings.showBackgroundBlocks ? "active" : ""}`}
-                >
-                  <span
-                    className={`settings-toggle-knob ${settings.showBackgroundBlocks ? "active" : ""}`}
-                  />
-                </span>
-              </label>
+    <>
+      {/* Fixed Toast Notifications */}
+      {(saveSuccess || cacheCleared) && (
+        <div className="settings-toast-container">
+          {saveSuccess && (
+            <div className="settings-toast settings-toast-success">
+              ✓ Settings saved successfully!
             </div>
-          </div>
+          )}
+          {cacheCleared && (
+            <div className="settings-toast settings-toast-success">✓ Cache cleared!</div>
+          )}
+        </div>
+      )}
 
-          {/* RPC Strategy Section */}
-          <div className="settings-section no-margin">
-            <h2 className="settings-section-title">⚡ RPC Strategy</h2>
-            <p className="settings-section-description">
-              Choose how requests are sent to multiple RPC endpoints.
-            </p>
+      <div className="container-medium page-container-padded">
+        <div className="page-card settings-container">
+          <h1 className="page-title-small">Settings</h1>
 
-            <div className="settings-item">
-              <div>
-                <div className="settings-item-label">Request Strategy</div>
-                <div className="settings-item-description">
-                  <strong>Fallback:</strong> Try endpoints one by one until one succeeds.
-                  <br />
-                  <strong>Parallel:</strong> Query all endpoints simultaneously.
-                </div>
-              </div>
-              <select
-                value={settings.rpcStrategy || "fallback"}
-                onChange={(e) =>
-                  updateSettings({
-                    rpcStrategy: e.target.value as "fallback" | "parallel",
-                  })
-                }
-                className="settings-select"
-              >
-                <option value="fallback">Fallback (Default)</option>
-                <option value="parallel">Parallel</option>
-              </select>
-            </div>
+          {/* Settings Grid: 2x2 layout */}
+          <div className="settings-grid">
+            {/* Appearance Settings Section */}
+            <div className="settings-section no-margin">
+              <h2 className="settings-section-title">🎨 Appearance</h2>
+              <p className="settings-section-description">
+                Customize the visual appearance of the application.
+              </p>
 
-            {/* Max Parallel Requests - Only show when parallel mode is active */}
-            {settings.rpcStrategy === "parallel" && (
               <div className="settings-item">
                 <div>
-                  <div className="settings-item-label">Max Parallel Requests</div>
+                  <div className="settings-item-label">Funny Background Blocks</div>
                   <div className="settings-item-description">
-                    Limit how many RPC endpoints are queried simultaneously. Lower values reduce
-                    bandwidth usage. Uses the first N endpoints from your RPC list (reorder by
-                    dragging).
+                    Show animated isometric blocks in the background
+                  </div>
+                </div>
+                <label className="settings-toggle">
+                  <input
+                    type="checkbox"
+                    checked={settings.showBackgroundBlocks ?? true}
+                    onChange={(e) => updateSettings({ showBackgroundBlocks: e.target.checked })}
+                    className="settings-toggle-input"
+                  />
+                  <span
+                    className={`settings-toggle-slider ${settings.showBackgroundBlocks ? "active" : ""}`}
+                  >
+                    <span
+                      className={`settings-toggle-knob ${settings.showBackgroundBlocks ? "active" : ""}`}
+                    />
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            {/* Cache & Data Section */}
+            <div className="settings-section no-margin">
+              <h2 className="settings-section-title">🗑️ Cache & Data</h2>
+              <p className="settings-section-description">
+                Manage cached data and application storage.
+              </p>
+
+              <div className="settings-item">
+                <div>
+                  <div className="settings-item-label">Clear Cache</div>
+                  <div className="settings-item-description">
+                    Clear cached metadata without losing your settings.
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="settings-clear-cache-button"
+                  onClick={clearAllCaches}
+                >
+                  🗑️ Clear Cache
+                </button>
+              </div>
+              <br />
+              <div className="settings-item">
+                <div>
+                  <div className="settings-item-label">Clear Site Data</div>
+                  <div className="settings-item-description">
+                    Clear all data including settings, RPC configs, and API keys.
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="settings-clear-site-data-button"
+                  onClick={clearSiteData}
+                >
+                  ⚠️ Clear Site Data
+                </button>
+              </div>
+            </div>
+
+            {/* RPC Strategy Section */}
+            <div className="settings-section no-margin">
+              <h2 className="settings-section-title">⚡ RPC Strategy</h2>
+              <p className="settings-section-description">
+                Choose how requests are sent to multiple RPC endpoints.
+              </p>
+
+              <div className="settings-item">
+                <div>
+                  <div className="settings-item-label">Request Strategy</div>
+                  <div className="settings-item-description">
+                    <strong>Fallback:</strong> Try endpoints one by one until one succeeds.
+                    <br />
+                    <strong>Parallel:</strong> Query all endpoints simultaneously.
                   </div>
                 </div>
                 <select
-                  value={settings.maxParallelRequests ?? 3}
+                  value={settings.rpcStrategy || "fallback"}
                   onChange={(e) =>
                     updateSettings({
-                      maxParallelRequests: Number(e.target.value),
+                      rpcStrategy: e.target.value as "fallback" | "parallel",
                     })
                   }
                   className="settings-select"
                 >
-                  <option value={1}>1 endpoint</option>
-                  <option value={2}>2 endpoints</option>
-                  <option value={3}>3 endpoints (Default)</option>
-                  <option value={5}>5 endpoints</option>
-                  <option value={10}>10 endpoints</option>
-                  <option value={0}>Unlimited</option>
+                  <option value="fallback">Fallback (Default)</option>
+                  <option value="parallel">Parallel</option>
                 </select>
               </div>
-            )}
-          </div>
-        </div>
 
-        {/* RPC Configuration Section */}
-        <div className="settings-section">
-          <h2 className="settings-section-title">🔗 RPC Endpoints</h2>
-          <p className="settings-section-description">
-            Enter comma-separated RPC URLs for each network. Multiple URLs provide fallback support.
-          </p>
-
-          <div className="flex-column settings-chain-list">
-            {chainConfigs.map((chain) => (
-              <div key={chain.id} className="settings-chain-item">
-                <div className="flex-column settings-chain-label">
-                  <div className="settings-chain-name">
-                    {chain.name}
-                    <span className="settings-chain-id-badge">Chain ID: {chain.id}</span>
-                    <button
-                      type="button"
-                      className="settings-fetch-rpc-button"
-                      onClick={() => fetchFromChainlist(chain.id)}
-                      disabled={fetchingChainId === chain.id}
-                    >
-                      {fetchingChainId === chain.id ? "Fetching..." : "Fetch from Chainlist"}
-                    </button>
-                  </div>
-                  <input
-                    className="settings-rpc-input"
-                    value={getLocalRpcString(chain.id)}
-                    onChange={(e) =>
-                      updateField(chain.id as keyof RpcUrlsContextType, e.target.value)
-                    }
-                    placeholder="https://eth-mainnet.g.alchemy.com/v2/YOUR-API-KEY"
-                  />
-
-                  {/* Help text for localhost network */}
-                  {chain.id === 31337 && (
-                    <div className="settings-help-text">
-                      💡 Need to access your local network remotely?{" "}
-                      <a
-                        href="https://dashboard.ngrok.com/get-started/setup"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="settings-link"
-                      >
-                        Learn how to set up a tunnel with ngrok
-                      </a>
+              {/* Max Parallel Requests - Only show when parallel mode is active */}
+              {settings.rpcStrategy === "parallel" && (
+                <div className="settings-item">
+                  <div>
+                    <div className="settings-item-label">Max Parallel Requests</div>
+                    <div className="settings-item-description">
+                      Limit how many RPC endpoints are queried simultaneously. Lower values reduce
+                      bandwidth usage. Uses the first N endpoints from your RPC list (reorder by
+                      dragging).
                     </div>
-                  )}
+                  </div>
+                  <select
+                    value={settings.maxParallelRequests ?? 3}
+                    onChange={(e) =>
+                      updateSettings({
+                        maxParallelRequests: Number(e.target.value),
+                      })
+                    }
+                    className="settings-select"
+                  >
+                    <option value={1}>1 endpoint</option>
+                    <option value={2}>2 endpoints</option>
+                    <option value={3}>3 endpoints (Default)</option>
+                    <option value={5}>5 endpoints</option>
+                    <option value={10}>10 endpoints</option>
+                    <option value={0}>Unlimited</option>
+                  </select>
+                </div>
+              )}
+            </div>
 
-                  {/* Display current RPC list as tags */}
-                  {(() => {
-                    const rpcArray = getLocalRpcArray(chain.id);
-                    if (rpcArray.length === 0) return null;
-                    return (
-                      <div className="flex-column settings-rpc-list">
-                        <span className="settings-rpc-list-label">Current RPCs:</span>
-                        <div className="flex-start settings-rpc-tags">
-                          {rpcArray.map((url, idx) => (
-                            // biome-ignore lint/a11y/noStaticElementInteractions: Drag-and-drop requires these handlers
-                            <div
-                              key={url}
-                              className={`settings-rpc-tag ${draggedItem?.chainId === chain.id && draggedItem?.index === idx ? "dragging" : ""}`}
-                              draggable
-                              onDragStart={() => handleDragStart(chain.id, idx)}
-                              onDragOver={handleDragOver}
-                              onDrop={() => handleDrop(chain.id, idx)}
-                              onDragEnd={() => setDraggedItem(null)}
-                            >
-                              <span className="settings-rpc-tag-index">{idx + 1}</span>
-                              <span className="settings-rpc-tag-url">{url}</span>
-                              <button
-                                type="button"
-                                className="settings-rpc-tag-delete"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  deleteRpc(chain.id, idx);
-                                }}
-                                title="Remove RPC"
-                              >
-                                ×
-                              </button>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    );
-                  })()}
+            {/* API Keys Section */}
+            <div className="settings-section no-margin">
+              <h2 className="settings-section-title">🔑 API Keys</h2>
+              <p className="settings-section-description">Enter your API keys for RPC providers.</p>
+
+              <div className="settings-api-key-item">
+                <div className="settings-api-key-header">
+                  <span className="settings-api-key-name">Infura</span>
+                  <a
+                    href="https://app.infura.io/dashboard"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="settings-api-key-link"
+                  >
+                    Get Key →
+                  </a>
+                </div>
+                <div className="settings-api-key-input-wrapper">
+                  <input
+                    type={showApiKeys.infura ? "text" : "password"}
+                    className="settings-rpc-input"
+                    value={localApiKeys.infura}
+                    onChange={(e) =>
+                      setLocalApiKeys((prev) => ({ ...prev, infura: e.target.value }))
+                    }
+                    placeholder="Enter your Infura API key"
+                  />
+                  <button
+                    type="button"
+                    className="settings-api-key-toggle"
+                    onClick={() => setShowApiKeys((prev) => ({ ...prev, infura: !prev.infura }))}
+                    title={showApiKeys.infura ? "Hide API key" : "Show API key"}
+                  >
+                    {showApiKeys.infura ? "👁️" : "👁️‍🗨️"}
+                  </button>
                 </div>
               </div>
-            ))}
 
-            {/** biome-ignore lint/a11y/useButtonType: <TODO> */}
-            <button onClick={save} className="settings-save-button">
+              <div className="settings-api-key-item">
+                <div className="settings-api-key-header">
+                  <span className="settings-api-key-name">Alchemy</span>
+                  <a
+                    href="https://dashboard.alchemy.com/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="settings-api-key-link"
+                  >
+                    Get Key →
+                  </a>
+                </div>
+                <div className="settings-api-key-input-wrapper">
+                  <input
+                    type={showApiKeys.alchemy ? "text" : "password"}
+                    className="settings-rpc-input"
+                    value={localApiKeys.alchemy}
+                    onChange={(e) =>
+                      setLocalApiKeys((prev) => ({ ...prev, alchemy: e.target.value }))
+                    }
+                    placeholder="Enter your Alchemy API key"
+                  />
+                  <button
+                    type="button"
+                    className="settings-api-key-toggle"
+                    onClick={() => setShowApiKeys((prev) => ({ ...prev, alchemy: !prev.alchemy }))}
+                    title={showApiKeys.alchemy ? "Hide API key" : "Show API key"}
+                  >
+                    {showApiKeys.alchemy ? "👁️" : "👁️‍🗨️"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Save Button - positioned after general settings */}
+          <div className="settings-save-section">
+            <button type="button" onClick={save} className="settings-save-button">
               💾 Save Configuration
             </button>
           </div>
+
+          {/* RPC Configuration Section */}
+          <div className="settings-section">
+            <h2 className="settings-section-title">🔗 RPC Endpoints</h2>
+            <p className="settings-section-description">
+              Configure RPC URLs for each network. Click on a network to expand and configure its
+              endpoints.
+            </p>
+
+            <div className="flex-column settings-chain-list">
+              {chainConfigs.map((chain) => {
+                const isExpanded = expandedChains.has(chain.id);
+                const rpcCount = getLocalRpcArray(chain.id).length;
+
+                return (
+                  <div key={chain.id} className="settings-chain-item">
+                    {/* Collapsible Header */}
+                    <button
+                      type="button"
+                      className="settings-chain-header"
+                      onClick={() => toggleChainExpanded(chain.id)}
+                    >
+                      <div className="settings-chain-header-left">
+                        <span className={`settings-chain-chevron ${isExpanded ? "expanded" : ""}`}>
+                          ▶
+                        </span>
+                        <span className="settings-chain-name-text">{chain.name}</span>
+                        <span className="settings-chain-id-badge">Chain ID: {chain.id}</span>
+                      </div>
+                      <span className="settings-chain-rpc-count">
+                        {rpcCount} RPC{rpcCount !== 1 ? "s" : ""}
+                      </span>
+                    </button>
+
+                    {/* Collapsible Content */}
+                    {isExpanded && (
+                      <div className="settings-chain-content">
+                        <div className="settings-chain-actions">
+                          <button
+                            type="button"
+                            className="settings-fetch-rpc-button"
+                            onClick={() => fetchFromChainlist(chain.id)}
+                            disabled={fetchingChainId === chain.id}
+                          >
+                            {fetchingChainId === chain.id ? "Fetching..." : "Fetch from Chainlist"}
+                          </button>
+                        </div>
+
+                        <input
+                          className="settings-rpc-input"
+                          value={getLocalRpcString(chain.id)}
+                          onChange={(e) =>
+                            updateField(chain.id as keyof RpcUrlsContextType, e.target.value)
+                          }
+                          placeholder="https://eth-mainnet.g.alchemy.com/v2/YOUR-API-KEY"
+                        />
+
+                        {/* Help text for localhost network */}
+                        {chain.id === 31337 && (
+                          <div className="settings-help-text">
+                            💡 Need to access your local network remotely?{" "}
+                            <a
+                              href="https://dashboard.ngrok.com/get-started/setup"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="settings-link"
+                            >
+                              Learn how to set up a tunnel with ngrok
+                            </a>
+                          </div>
+                        )}
+
+                        {/* Display current RPC list as tags */}
+                        {(() => {
+                          const rpcArray = getLocalRpcArray(chain.id);
+                          if (rpcArray.length === 0) return null;
+                          return (
+                            <div className="flex-column settings-rpc-list">
+                              <span className="settings-rpc-list-label">Current RPCs:</span>
+                              <div className="flex-start settings-rpc-tags">
+                                {rpcArray.map((url, idx) => (
+                                  // biome-ignore lint/a11y/noStaticElementInteractions: Drag-and-drop requires these handlers
+                                  <div
+                                    key={url}
+                                    className={`settings-rpc-tag ${draggedItem?.chainId === chain.id && draggedItem?.index === idx ? "dragging" : ""}`}
+                                    draggable
+                                    onDragStart={() => handleDragStart(chain.id, idx)}
+                                    onDragOver={handleDragOver}
+                                    onDrop={() => handleDrop(chain.id, idx)}
+                                    onDragEnd={() => setDraggedItem(null)}
+                                  >
+                                    <span className="settings-rpc-tag-index">{idx + 1}</span>
+                                    {getProviderBadge(url) ? (
+                                      <span className="settings-rpc-tag-provider">
+                                        {getProviderBadge(url)}
+                                      </span>
+                                    ) : (
+                                      <span className="settings-rpc-tag-url">{url}</span>
+                                    )}
+                                    <button
+                                      type="button"
+                                      className="settings-rpc-tag-delete"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        deleteRpc(chain.id, idx);
+                                      }}
+                                      title="Remove RPC"
+                                    >
+                                      ×
+                                    </button>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          );
+                        })()}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -4742,8 +4742,16 @@ code {
   margin-bottom: 24px;
 }
 
+.settings-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
 @media (max-width: 768px) {
-  .settings-top-row {
+  .settings-top-row,
+  .settings-grid {
     grid-template-columns: 1fr;
   }
 }
@@ -4991,6 +4999,14 @@ code {
   flex: 1;
 }
 
+.settings-rpc-tag-provider {
+  font-weight: 700;
+  font-size: 0.7rem;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  flex: 1;
+}
+
 .settings-save-button {
   padding: 12px 24px;
   background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-muted) 100%);
@@ -5010,6 +5026,219 @@ code {
 .settings-save-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 16px var(--color-primary-alpha-40);
+}
+
+/* Sticky Save Button Container */
+/* Save Section */
+.settings-save-section {
+  display: flex;
+  justify-content: center;
+  padding: 16px 0;
+  margin-bottom: 8px;
+}
+
+/* API Keys Section */
+.settings-api-keys-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-api-key-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.settings-api-key-item:first-child {
+  margin-top: 0;
+}
+
+.settings-api-key-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.settings-api-key-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.settings-api-key-link {
+  font-size: 0.8rem;
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.settings-api-key-link:hover {
+  text-decoration: underline;
+}
+
+.settings-api-key-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.settings-api-key-input-wrapper .settings-rpc-input {
+  padding-right: 40px;
+}
+
+.settings-api-key-toggle {
+  position: absolute;
+  right: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 4px;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+
+.settings-api-key-toggle:hover {
+  opacity: 1;
+}
+
+/* Toast Notifications */
+.settings-toast-container {
+  position: fixed;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-toast {
+  padding: 12px 24px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  font-family: "Outfit", sans-serif;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  animation: slideDown 0.3s ease;
+}
+
+.settings-toast-success {
+  background: linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-muted) 100%);
+  color: white;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Collapsible Chain Header */
+.settings-chain-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: "Outfit", sans-serif;
+  transition: background 0.2s ease;
+  border-radius: 8px;
+}
+
+.settings-chain-header:hover {
+  background: var(--color-primary-alpha-5);
+}
+
+.settings-chain-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.settings-chain-chevron {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  transition: transform 0.2s ease;
+}
+
+.settings-chain-chevron.expanded {
+  transform: rotate(90deg);
+}
+
+.settings-chain-name-text {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.settings-chain-rpc-count {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  background: var(--color-primary-alpha-10);
+  padding: 4px 10px;
+  border-radius: 12px;
+}
+
+.settings-chain-content {
+  padding: 12px 16px 16px;
+  border-top: 1px solid var(--color-primary-alpha-10);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.settings-chain-actions {
+  display: flex;
+  gap: 8px;
+}
+
+/* Clear Cache Button */
+.settings-clear-cache-button {
+  padding: 8px 16px;
+  background: var(--color-error-alpha-10, rgba(239, 68, 68, 0.1));
+  color: var(--color-error, #ef4444);
+  border: 1px solid var(--color-error-alpha-30, rgba(239, 68, 68, 0.3));
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: "Outfit", sans-serif;
+}
+
+.settings-clear-cache-button:hover {
+  background: var(--color-error-alpha-20, rgba(239, 68, 68, 0.2));
+  border-color: var(--color-error, #ef4444);
+}
+
+.settings-clear-site-data-button {
+  padding: 8px 16px;
+  background: var(--color-error, #ef4444);
+  color: white;
+  border: 1px solid var(--color-error, #ef4444);
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: "Outfit", sans-serif;
+}
+
+.settings-clear-site-data-button:hover {
+  background: #dc2626;
+  border-color: #dc2626;
 }
 
 /* Toggle Switch */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -264,6 +264,14 @@ export type RpcUrlsContextType = Record<number, RPCUrls>;
 // ==================== SETTINGS TYPES ====================
 
 /**
+ * API keys for RPC providers
+ */
+export interface ApiKeys {
+  infura?: string;
+  alchemy?: string;
+}
+
+/**
  * User settings for the application
  */
 export interface UserSettings {
@@ -271,6 +279,7 @@ export interface UserSettings {
   showBackgroundBlocks?: boolean;
   rpcStrategy?: "fallback" | "parallel";
   maxParallelRequests?: number;
+  apiKeys?: ApiKeys;
 }
 
 /**
@@ -281,6 +290,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   showBackgroundBlocks: true,
   rpcStrategy: "fallback",
   maxParallelRequests: 3,
+  apiKeys: {},
 };
 
 /**


### PR DESCRIPTION
## Description

Enhance the settings page with improved UX, collapsible RPC sections, API keys management for providers, and comprehensive cache/data clearing options.

## Related Issue

<!-- No direct issue linked -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Make network RPC sections collapsible with chevron toggle for better organization
- Add API Keys section for Infura and Alchemy providers in 2x2 grid layout
- Auto-add/remove provider RPC URLs when API keys are saved or removed
- Show INFURA/ALCHEMY badges on provider RPC tags for easy identification
- Add eye icon toggle to show/hide API key values for security
- Add Clear Cache button for metadata service cache
- Add Clear Site Data button for comprehensive browser data clearing (localStorage, sessionStorage, cookies, IndexedDB, Cache Storage, Service Workers)
- Reorganize settings into 2x2 grid layout (Appearance, RPC Strategy, API Keys, Cache & Data)
- Fix toast notification positioning with fixed display so it's always visible

## Screenshots (if applicable)

<!-- Manual testing recommended -->

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

- API keys are stored in localStorage and persisted across sessions
- Provider URLs are automatically generated based on API keys and network support
- The Clear Site Data button provides the same functionality as browser dev tools "Clear site data"