### PR TITLE
fix(build): read version from package.json

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,11 @@
 import { execSync } from "child_process";
+import { readFileSync } from "fs";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+
+// Get version from package.json
+const packageJson = JSON.parse(readFileSync("./package.json", "utf-8"));
+const appVersion = packageJson.version || "0.0.0";
 
 // Get git commit hash
 let commitHash = "development";
@@ -46,7 +51,7 @@ export default defineConfig({
         "https://github.com/openscan-explorer/explorer"
     ),
     "process.env.REACT_APP_VERSION": JSON.stringify(
-      process.env.REACT_APP_VERSION || "1.0.0-alpha"
+      process.env.REACT_APP_VERSION || appVersion
     ),
     "process.env.REACT_APP_OPENSCAN_NETWORKS": JSON.stringify(
       process.env.REACT_APP_OPENSCAN_NETWORKS || ""


### PR DESCRIPTION
## Description

Fix the footer version display to read from package.json instead of using a hardcoded fallback.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Import and read package.json in vite.config.ts
- Use the version from package.json as fallback instead of hardcoded "1.0.0-alpha"

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run npm run format:fix and npm run lint:fix
- [x] I have run npm run typecheck with no errors
- [x] I have run tests with npm run test:run
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

This ensures the footer displays the correct version from package.json (currently 1.1.0-alpha) instead of the old hardcoded 1.0.0-alpha fallback.