### PR TITLE
fix(subdomain): enable ENS gateway subdomain detection

### DIFF
--- a/src/utils/subdomainUtils.ts
+++ b/src/utils/subdomainUtils.ts
@@ -18,8 +18,15 @@ export function getSubdomain(): string | null {
     return null;
   }
 
-  // Skip subdomain processing for ENS gateways (e.g., openscan.eth.link, openscan.eth.limo)
+  // Handle ENS gateway subdomains (e.g., ethereum.openscan.eth.link -> ethereum)
+  // These resolve ENS subdomains like ethereum.openscan.eth
   if (hostname.endsWith(".eth.link") || hostname.endsWith(".eth.limo")) {
+    const parts = hostname.split(".");
+    // ethereum.openscan.eth.link = 4 parts, openscan.eth.link = 3 parts
+    // ethereum.openscan.eth.limo = 4 parts, openscan.eth.limo = 3 parts
+    if (parts.length > 3 && parts[0]) {
+      return parts[0];
+    }
     return null;
   }
 


### PR DESCRIPTION
## Description

Enable subdomain detection for ENS gateways (eth.link, eth.limo) so that ENS subdomains like `ethereum.openscan.eth` can be accessed via `ethereum.openscan.eth.link`.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Updated `getSubdomain()` in `src/utils/subdomainUtils.ts` to detect ENS subdomains
- Previously, all `.eth.link` and `.eth.limo` hostnames returned `null` (subdomain detection was skipped)
- Now, hostnames with more than 3 parts (e.g., `ethereum.openscan.eth.link`) return the first part as the subdomain

## How It Works

| Hostname | Parts | Subdomain Detected |
|----------|-------|-------------------|
| `openscan.eth.link` | 3 | `null` (base domain) |
| `ethereum.openscan.eth.link` | 4 | `ethereum` |
| `arbitrum.openscan.eth.link` | 4 | `arbitrum` |

## Setup Required

To use ENS subdomains, you need to:
1. Create the ENS subdomain (e.g., `ethereum.openscan.eth`)
2. Set the content hash on that subdomain to the IPFS deployment

## Checklist

- [x] I have run npm run format:fix and npm run lint:fix
- [x] I have run npm run typecheck with no errors
- [x] I have run tests with npm run test:run
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns