### PR TITLE
feat: enable transaction history for all networks

### DIFF
--- a/src/services/adapters/ArbitrumAdapter/ArbitrumAdapter.ts
+++ b/src/services/adapters/ArbitrumAdapter/ArbitrumAdapter.ts
@@ -1,12 +1,5 @@
 import { type BlockNumberOrTag, NetworkAdapter, type TraceResult } from "../NetworkAdapter";
-import type {
-  Block,
-  Transaction,
-  Address,
-  NetworkStats,
-  DataWithMetadata,
-  AddressTransactionsResult,
-} from "../../../types";
+import type { Block, Transaction, Address, NetworkStats, DataWithMetadata } from "../../../types";
 import {
   transformArbitrumBlockToBlock,
   transformArbitrumTransactionToTransaction,
@@ -16,7 +9,7 @@ import {
 import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
-import type { ArbitrumClient } from "@openscan/network-connectors";
+import type { ArbitrumClient, EthereumClient } from "@openscan/network-connectors";
 
 /**
  * Arbitrum blockchain adapter
@@ -30,6 +23,7 @@ export class ArbitrumAdapter extends NetworkAdapter {
   constructor(networkId: 42161, client: ArbitrumClient) {
     super(networkId);
     this.client = client;
+    this.initTxSearch(client as unknown as EthereumClient);
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
@@ -128,25 +122,6 @@ export class ArbitrumAdapter extends NetworkAdapter {
     return {
       data: addressData,
       metadata: balanceResult.metadata as DataWithMetadata<Address>["metadata"],
-    };
-  }
-
-  async getAddressTransactions(
-    _address: string,
-    _fromBlock?: number | "earliest",
-    _toBlock?: number | "latest",
-    _limit = 100,
-  ): Promise<AddressTransactionsResult> {
-    // Arbitrum doesn't have a native method to get transactions by address
-    // This would require scanning blocks or using an indexer
-    // For now, return empty result
-    console.warn("getAddressTransactions not fully implemented for Arbitrum");
-
-    return {
-      transactions: [],
-      source: "none",
-      isComplete: false,
-      message: "Address transaction lookup not supported without indexer",
     };
   }
 

--- a/src/services/adapters/BNBAdapter/BNBAdapter.ts
+++ b/src/services/adapters/BNBAdapter/BNBAdapter.ts
@@ -1,12 +1,5 @@
 import { type BlockNumberOrTag, NetworkAdapter } from "../NetworkAdapter";
-import type {
-  Block,
-  Transaction,
-  Address,
-  NetworkStats,
-  DataWithMetadata,
-  AddressTransactionsResult,
-} from "../../../types";
+import type { Block, Transaction, Address, NetworkStats, DataWithMetadata } from "../../../types";
 import type { TraceResult } from "../NetworkAdapter";
 import {
   transformBNBBlockToBlock,
@@ -17,7 +10,7 @@ import {
 import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
-import type { BNBClient } from "@openscan/network-connectors";
+import type { BNBClient, EthereumClient } from "@openscan/network-connectors";
 
 /**
  * BNB Smart Chain (BSC) blockchain adapter
@@ -30,6 +23,7 @@ export class BNBAdapter extends NetworkAdapter {
   constructor(networkId: 56 | 97, client: BNBClient) {
     super(networkId);
     this.client = client;
+    this.initTxSearch(client as unknown as EthereumClient);
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
@@ -128,25 +122,6 @@ export class BNBAdapter extends NetworkAdapter {
     return {
       data: addressData,
       metadata: balanceResult.metadata as DataWithMetadata<Address>["metadata"],
-    };
-  }
-
-  async getAddressTransactions(
-    _address: string,
-    _fromBlock?: number | "earliest",
-    _toBlock?: number | "latest",
-    _limit = 100,
-  ): Promise<AddressTransactionsResult> {
-    // BNB doesn't have a native method to get transactions by address
-    // This would require scanning blocks or using an indexer
-    // For now, return empty result
-    console.warn("getAddressTransactions not fully implemented for BNB chain");
-
-    return {
-      transactions: [],
-      source: "none",
-      isComplete: false,
-      message: "Address transaction lookup not supported without indexer",
     };
   }
 

--- a/src/services/adapters/BaseAdapter/BaseAdapter.ts
+++ b/src/services/adapters/BaseAdapter/BaseAdapter.ts
@@ -1,12 +1,5 @@
 import { type BlockNumberOrTag, NetworkAdapter, type TraceResult } from "../NetworkAdapter";
-import type {
-  Block,
-  Transaction,
-  Address,
-  NetworkStats,
-  DataWithMetadata,
-  AddressTransactionsResult,
-} from "../../../types";
+import type { Block, Transaction, Address, NetworkStats, DataWithMetadata } from "../../../types";
 import {
   transformBaseBlockToBlock,
   transformBaseTransactionToTransaction,
@@ -16,7 +9,7 @@ import {
 import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
-import type { BaseClient } from "@openscan/network-connectors";
+import type { BaseClient, EthereumClient } from "@openscan/network-connectors";
 
 /**
  * Base blockchain adapter
@@ -29,6 +22,7 @@ export class BaseAdapter extends NetworkAdapter {
   constructor(networkId: 8453, client: BaseClient) {
     super(networkId);
     this.client = client;
+    this.initTxSearch(client as unknown as EthereumClient);
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
@@ -127,25 +121,6 @@ export class BaseAdapter extends NetworkAdapter {
     return {
       data: addressData,
       metadata: balanceResult.metadata as DataWithMetadata<Address>["metadata"],
-    };
-  }
-
-  async getAddressTransactions(
-    _address: string,
-    _fromBlock?: number | "earliest",
-    _toBlock?: number | "latest",
-    _limit = 100,
-  ): Promise<AddressTransactionsResult> {
-    // Base doesn't have a native method to get transactions by address
-    // This would require scanning blocks or using an indexer
-    // For now, return empty result
-    console.warn("getAddressTransactions not fully implemented for Base");
-
-    return {
-      transactions: [],
-      source: "none",
-      isComplete: false,
-      message: "Address transaction lookup not supported without indexer",
     };
   }
 

--- a/src/services/adapters/EVMAdapter/EVMAdapter.ts
+++ b/src/services/adapters/EVMAdapter/EVMAdapter.ts
@@ -1,12 +1,5 @@
 import { type BlockNumberOrTag, NetworkAdapter } from "../NetworkAdapter";
-import type {
-  Block,
-  Transaction,
-  Address,
-  NetworkStats,
-  DataWithMetadata,
-  AddressTransactionsResult,
-} from "../../../types";
+import type { Block, Transaction, Address, NetworkStats, DataWithMetadata } from "../../../types";
 import type { TraceResult } from "../NetworkAdapter";
 import {
   transformRPCBlockToBlock,
@@ -18,7 +11,6 @@ import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
 import type { EthereumClient, SupportedChainId } from "@openscan/network-connectors";
-import { AddressTransactionSearch } from "../../AddressTransactionSearch";
 
 /**
  * EVM-compatible blockchain service
@@ -26,12 +18,11 @@ import { AddressTransactionSearch } from "../../AddressTransactionSearch";
  */
 export class EVMAdapter extends NetworkAdapter {
   private client: EthereumClient;
-  private txSearch: AddressTransactionSearch;
 
   constructor(networkId: SupportedChainId | 11155111 | 97 | 31337, client: EthereumClient) {
     super(networkId);
     this.client = client;
-    this.txSearch = new AddressTransactionSearch(client);
+    this.initTxSearch(client);
   }
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
     const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
@@ -130,69 +121,6 @@ export class EVMAdapter extends NetworkAdapter {
       data: addressData,
       metadata: balanceResult.metadata as DataWithMetadata<Address>["metadata"],
     };
-  }
-
-  async getAddressTransactions(
-    address: string,
-    fromBlock?: number | "earliest",
-    toBlock?: number | "latest",
-    limit = 100,
-    onTransactionsFound?: (txs: Transaction[]) => void,
-  ): Promise<AddressTransactionsResult> {
-    try {
-      // Use binary search on nonce/balance to find important blocks
-      // Pass the streaming callback to get transactions as they are found
-      const result = await this.txSearch.searchAddressActivity(address, {
-        limit,
-        toBlock: typeof toBlock === "number" ? toBlock : undefined,
-        fromBlock: typeof fromBlock === "number" ? fromBlock : undefined,
-        onTransactionsFound: onTransactionsFound
-          ? (txs) => {
-              // Strip the 'type' property from transactions before passing to callback
-              const cleanTxs = txs.map(({ type: _type, ...tx }) => tx as Transaction);
-              onTransactionsFound(cleanTxs);
-            }
-          : undefined,
-      });
-
-      if (result.transactions.length === 0) {
-        return {
-          transactions: [],
-          transactionDetails: [],
-          source: "none",
-          isComplete: true,
-          message: "No transactions found for this address",
-        };
-      }
-
-      // Extract transaction hashes and clean transaction details
-      const txHashes = result.transactions.map((tx) => tx.hash);
-      const txDetails = result.transactions.map(({ type: _type, ...tx }) => tx as Transaction);
-
-      return {
-        transactions: txHashes,
-        transactionDetails: txDetails,
-        source: "binary_search",
-        isComplete: result.stats.totalTxs < limit || limit === 0,
-        message:
-          limit > 0 && result.stats.totalTxs >= limit
-            ? `Showing ${limit} transactions (more may exist)`
-            : undefined,
-      };
-    } catch (error) {
-      console.error("Error searching address transactions:", error);
-
-      return {
-        transactions: [],
-        transactionDetails: [],
-        source: "none",
-        isComplete: false,
-        message:
-          error instanceof Error
-            ? `Search failed: ${error.message}`
-            : "Address transaction lookup failed",
-      };
-    }
   }
 
   async getLatestBlockNumber(): Promise<number> {

--- a/src/services/adapters/NetworkAdapter.ts
+++ b/src/services/adapters/NetworkAdapter.ts
@@ -1,4 +1,4 @@
-import type { SupportedChainId } from "@openscan/network-connectors";
+import type { SupportedChainId, EthereumClient } from "@openscan/network-connectors";
 import type {
   Block,
   Transaction,
@@ -7,6 +7,7 @@ import type {
   DataWithMetadata,
   AddressTransactionsResult,
 } from "../../types";
+import { AddressTransactionSearch } from "../AddressTransactionSearch";
 
 export type BlockTag = "latest" | "earliest" | "pending" | "finalized" | "safe";
 export type BlockNumberOrTag = number | string | BlockTag;
@@ -44,10 +45,19 @@ export interface TraceCallConfig {
 export abstract class NetworkAdapter {
   networkId: number;
   isLocalHost: boolean;
+  protected txSearch: AddressTransactionSearch | null = null;
 
   constructor(networkId: SupportedChainId | 31337 | 11155111 | 97) {
     this.networkId = networkId;
     this.isLocalHost = networkId === 31337;
+  }
+
+  /**
+   * Initialize the transaction search service
+   * Call this in subclass constructors to enable binary search tx discovery
+   */
+  protected initTxSearch(client: EthereumClient): void {
+    this.txSearch = new AddressTransactionSearch(client);
   }
   /**
    * Get block by number or tag
@@ -80,20 +90,81 @@ export abstract class NetworkAdapter {
   abstract getAddress(address: string): Promise<DataWithMetadata<Address>>;
 
   /**
-   * Get transactions for an address
+   * Get transactions for an address using binary search on nonce/balance changes
    * @param address - Address to query
    * @param fromBlock - Starting block (optional)
    * @param toBlock - Ending block (optional)
    * @param limit - Maximum number of transactions to return
+   * @param onTransactionsFound - Callback for streaming results
    * @returns List of transactions
    */
-  abstract getAddressTransactions(
+  async getAddressTransactions(
     address: string,
     fromBlock?: number | "earliest",
     toBlock?: number | "latest",
-    limit?: number,
+    limit = 100,
     onTransactionsFound?: (txs: Transaction[]) => void,
-  ): Promise<AddressTransactionsResult>;
+  ): Promise<AddressTransactionsResult> {
+    if (!this.txSearch) {
+      return {
+        transactions: [],
+        source: "none",
+        isComplete: false,
+        message: "Transaction search not initialized for this network",
+      };
+    }
+
+    try {
+      const result = await this.txSearch.searchAddressActivity(address, {
+        limit,
+        toBlock: typeof toBlock === "number" ? toBlock : undefined,
+        fromBlock: typeof fromBlock === "number" ? fromBlock : undefined,
+        onTransactionsFound: onTransactionsFound
+          ? (txs) => {
+              const cleanTxs = txs.map(({ type: _type, ...tx }) => tx as Transaction);
+              onTransactionsFound(cleanTxs);
+            }
+          : undefined,
+      });
+
+      if (result.transactions.length === 0) {
+        return {
+          transactions: [],
+          transactionDetails: [],
+          source: "none",
+          isComplete: true,
+          message: "No transactions found for this address",
+        };
+      }
+
+      const txHashes = result.transactions.map((tx) => tx.hash);
+      const txDetails = result.transactions.map(({ type: _type, ...tx }) => tx as Transaction);
+
+      return {
+        transactions: txHashes,
+        transactionDetails: txDetails,
+        source: "binary_search",
+        isComplete: result.stats.totalTxs < limit || limit === 0,
+        message:
+          limit > 0 && result.stats.totalTxs >= limit
+            ? `Showing ${limit} transactions (more may exist)`
+            : undefined,
+      };
+    } catch (error) {
+      console.error("Error searching address transactions:", error);
+
+      return {
+        transactions: [],
+        transactionDetails: [],
+        source: "none",
+        isComplete: false,
+        message:
+          error instanceof Error
+            ? `Search failed: ${error.message}`
+            : "Address transaction lookup failed",
+      };
+    }
+  }
 
   /**
    * Get the latest block number

--- a/src/services/adapters/OptimismAdapter/OptimismAdapter.ts
+++ b/src/services/adapters/OptimismAdapter/OptimismAdapter.ts
@@ -1,12 +1,5 @@
 import { type BlockNumberOrTag, NetworkAdapter, type TraceResult } from "../NetworkAdapter";
-import type {
-  Block,
-  Transaction,
-  Address,
-  NetworkStats,
-  DataWithMetadata,
-  AddressTransactionsResult,
-} from "../../../types";
+import type { Block, Transaction, Address, NetworkStats, DataWithMetadata } from "../../../types";
 import {
   transformOptimismBlockToBlock,
   transformOptimismTransactionToTransaction,
@@ -16,7 +9,7 @@ import {
 import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
-import type { OptimismClient } from "@openscan/network-connectors";
+import type { OptimismClient, EthereumClient } from "@openscan/network-connectors";
 
 /**
  * Optimism (OP Stack) blockchain adapter
@@ -29,6 +22,7 @@ export class OptimismAdapter extends NetworkAdapter {
   constructor(networkId: 10, client: OptimismClient) {
     super(networkId);
     this.client = client;
+    this.initTxSearch(client as unknown as EthereumClient);
   }
 
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
@@ -127,25 +121,6 @@ export class OptimismAdapter extends NetworkAdapter {
     return {
       data: addressData,
       metadata: balanceResult.metadata as DataWithMetadata<Address>["metadata"],
-    };
-  }
-
-  async getAddressTransactions(
-    _address: string,
-    _fromBlock?: number | "earliest",
-    _toBlock?: number | "latest",
-    _limit = 100,
-  ): Promise<AddressTransactionsResult> {
-    // Optimism doesn't have a native method to get transactions by address
-    // This would require scanning blocks or using an indexer
-    // For now, return empty result
-    console.warn("getAddressTransactions not fully implemented for Optimism");
-
-    return {
-      transactions: [],
-      source: "none",
-      isComplete: false,
-      message: "Address transaction lookup not supported without indexer",
     };
   }
 

--- a/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
+++ b/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
@@ -1,12 +1,5 @@
 import { type BlockNumberOrTag, NetworkAdapter } from "../NetworkAdapter";
-import type {
-  Block,
-  Transaction,
-  Address,
-  NetworkStats,
-  DataWithMetadata,
-  AddressTransactionsResult,
-} from "../../../types";
+import type { Block, Transaction, Address, NetworkStats, DataWithMetadata } from "../../../types";
 import type { TraceResult } from "../NetworkAdapter";
 import {
   transformPolygonBlockToBlock,
@@ -17,7 +10,7 @@ import {
 import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
-import type { PolygonClient, SupportedChainId } from "@openscan/network-connectors";
+import type { PolygonClient, SupportedChainId, EthereumClient } from "@openscan/network-connectors";
 
 /**
  * Polygon blockchain service
@@ -29,6 +22,7 @@ export class PolygonAdapter extends NetworkAdapter {
   constructor(networkId: SupportedChainId, client: PolygonClient) {
     super(networkId);
     this.client = client;
+    this.initTxSearch(client as unknown as EthereumClient);
   }
   async getBlock(blockNumber: BlockNumberOrTag): Promise<DataWithMetadata<Block>> {
     const normalizedBlockNumber = normalizeBlockNumber(blockNumber);
@@ -126,25 +120,6 @@ export class PolygonAdapter extends NetworkAdapter {
     return {
       data: addressData,
       metadata: balanceResult.metadata as DataWithMetadata<Address>["metadata"],
-    };
-  }
-
-  async getAddressTransactions(
-    _address: string,
-    _fromBlock?: number | "earliest",
-    _toBlock?: number | "latest",
-    _limit = 100,
-  ): Promise<AddressTransactionsResult> {
-    // Polygon doesn't have a native method to get transactions by address
-    // This would require scanning blocks or using an indexer
-    // For now, return empty result
-    console.warn("getAddressTransactions not fully implemented for Polygon");
-
-    return {
-      transactions: [],
-      source: "none",
-      isComplete: false,
-      message: "Address transaction lookup not supported without indexer",
     };
   }
 


### PR DESCRIPTION
## Description

Enable binary search transaction discovery for all networks by moving the implementation from EVMAdapter to the NetworkAdapter base class. Previously, only Ethereum mainnet had working transaction history - now it works on Arbitrum, Optimism, Base, Polygon, and BNB.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Add `txSearch` property and `initTxSearch()` method to NetworkAdapter base class
- Move `getAddressTransactions()` implementation from EVMAdapter to NetworkAdapter
- Update all adapters to call `initTxSearch(client)` in their constructors:
  - EVMAdapter
  - ArbitrumAdapter
  - OptimismAdapter
  - BaseAdapter
  - PolygonAdapter
  - BNBAdapter
- Remove stub `getAddressTransactions()` implementations from all network-specific adapters

**Result:** 126 lines of duplicated code removed (93 added, 219 deleted)

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

The binary search algorithm uses nonce/balance state changes to discover transactions without relying on indexers. This approach works on any EVM-compatible network with standard RPC methods (`eth_getTransactionCount`, `eth_getBalance`).