### PR TITLE
Fix infure and alchemy badges not displaying on save

### DIFF
--- a/src/components/pages/settings/index.tsx
+++ b/src/components/pages/settings/index.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { getEnabledNetworks } from "../../../config/networks";
 import { AppContext } from "../../../context/AppContext";
 import { useSettings } from "../../../context/SettingsContext";
@@ -64,6 +64,11 @@ const Settings: React.FC = () => {
     infura: false,
     alchemy: false,
   });
+
+  // Sync localRpc when context rpcUrls changes (e.g., after save)
+  useEffect(() => {
+    setLocalRpc({ ...rpcUrls });
+  }, [rpcUrls]);
 
   const updateField = (key: keyof RpcUrlsContextType, value: string) => {
     setLocalRpc((prev) => ({ ...prev, [key]: value }));


### PR DESCRIPTION
## Description

Fix state synchronization issue in Settings page where Alchemy and Infura provider badges don't display immediately after saving API keys configuration.

## Related Issue

Closes #177

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `useEffect` hook to synchronize `localRpc` state when `rpcUrls` context changes
- The `localRpc` state was initialized once at mount from context but never updated when context changed after save
- Now badges appear immediately after clicking "Save Configuration" without requiring navigation

## Screenshots (if applicable)

N/A - Behavior fix, no visual changes

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

**Root cause:** The Settings component's `localRpc` state was a one-time snapshot of `rpcUrls` from AppContext. When `save()` updated the context via `setRpcUrls(parsed)`, `localRpc` was never synchronized. The RPC list rendered from stale `localRpc`, so badges didn't appear until the component remounted on navigation.
