### PR TITLE
chore: bump version to 1.2.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "openscan",
-	"version": "1.1.1-alpha",
+	"version": "1.2.0-alpha",
 	"private": true,
 	"type": "module",
 	"packageManager": "bun@1.1.0",


### PR DESCRIPTION
## Summary

Bumps version from 1.1.1-alpha to 1.2.0-alpha for the v1.2.0 release.