### PR TITLE
Publish using OIDC and set npm registry for github acation

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,12 +30,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
         uses: JS-DevTools/npm-publish@v4
         with:
+          registry: "https://registry.npmjs.org/"
           package: ./dist
-          access: public
-          provenance: true


### PR DESCRIPTION
## Description

Remove unnecesary fields for JS-DevTools/npm-publish@v4 that are causing config conflicts on publish.

## Related Issue

<!-- Link to the related issue (e.g., Closes #123) -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Use node 24 for publish
- Remove unnecesary parameters from JS-DevTools/npm-publish@v4 of npm-publish.yml action

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

<!-- Any additional information that reviewers should know -->
