### PR TITLE
fix(html): remove static preload content from root div

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,58 +155,7 @@
         <p><a href="https://github.com/openscan-explorer/explorer" style="color:#58a6ff;">View on GitHub</a></p>
       </div>
     </noscript>
-    <div id="root">
-      <!-- Static content for crawlers and AI indexing. Replaced by React on mount. -->
-      <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#e0e0e0;background:#0a0a0a;">
-        <h1>OpenScan - Open-Source Blockchain Explorer</h1>
-        <p>OpenScan is a trustless, open-source blockchain explorer for Bitcoin, Ethereum, and EVM-compatible networks. Connect directly to blockchain nodes with no intermediaries, no tracking, and no data harvesting.</p>
-
-        <h2>Features</h2>
-        <ul>
-          <li><strong>Multi-Chain Explorer</strong> - Browse blocks, transactions, and addresses across Ethereum, Arbitrum, Optimism, Base, Polygon, BSC, and Bitcoin.</li>
-          <li><strong>Smart Contract Interaction</strong> - Read from and write to verified smart contracts directly from the explorer.</li>
-          <li><strong>ENS Domain Lookup</strong> - Resolve Ethereum Name Service domains to addresses.</li>
-          <li><strong>Local Development Support</strong> - Explore Hardhat and Anvil local chains with trace capabilities.</li>
-          <li><strong>RPC Transparency</strong> - Compare responses across multiple RPC providers and detect inconsistencies.</li>
-          <li><strong>Privacy First</strong> - No ads, no trackers, no user data collection. Fully open-source.</li>
-          <li><strong>Decentralized Deployment</strong> - Deployable on IPFS for censorship-resistant blockchain exploration.</li>
-        </ul>
-
-        <h2>Supported Networks</h2>
-        <ul>
-          <li>Ethereum (Mainnet) - Chain ID: 1</li>
-          <li>Arbitrum One - Chain ID: 42161</li>
-          <li>Optimism - Chain ID: 10</li>
-          <li>Base - Chain ID: 8453</li>
-          <li>Polygon - Chain ID: 137</li>
-          <li>BNB Smart Chain (BSC) - Chain ID: 56</li>
-          <li>Bitcoin</li>
-          <li>Sepolia Testnet - Chain ID: 11155111</li>
-        </ul>
-
-        <h2>Frequently Asked Questions</h2>
-
-        <h3>What is OpenScan?</h3>
-        <p>OpenScan is a free, open-source blockchain explorer that connects directly to blockchain nodes via RPC. Unlike centralized explorers like Etherscan, it does not rely on intermediary servers or indexed databases. It is trustless, privacy-focused, and supports multiple blockchain networks.</p>
-
-        <h3>What blockchain networks does OpenScan support?</h3>
-        <p>OpenScan supports Ethereum, Arbitrum, Optimism, Base, Polygon, BNB Smart Chain, Bitcoin, and local development chains (Hardhat, Anvil). Testnets including Sepolia are also available.</p>
-
-        <h3>Is OpenScan free to use?</h3>
-        <p>Yes. OpenScan is 100% free and open-source under the MIT license. There are no ads, no premium tiers, and no data collection.</p>
-
-        <h3>How is OpenScan different from Etherscan?</h3>
-        <p>OpenScan is trustless and decentralized. It connects directly to blockchain RPC nodes instead of relying on centralized indexing servers. It is also fully open-source, privacy-focused, supports multiple chains including Bitcoin, and can be deployed on IPFS for complete decentralization.</p>
-
-        <h3>Can I interact with smart contracts on OpenScan?</h3>
-        <p>Yes. OpenScan supports reading from and writing to verified smart contracts directly through the explorer interface. Connect your wallet and interact with any verified contract on supported EVM networks.</p>
-
-        <h3>Can I use OpenScan for local blockchain development?</h3>
-        <p>Yes. OpenScan has full support for local development chains including Hardhat and Anvil. It provides trace capabilities on localhost networks, making it useful for smart contract development and debugging.</p>
-
-        <p><a href="https://github.com/openscan-explorer/explorer" style="color:#58a6ff;">View source on GitHub</a></p>
-      </div>
-    </div>
+    <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Description

Remove the static HTML content inside `<div id="root">` that was added in PR #204. This content caused a flash of black-background text before React mounts, degrading the user experience.

SEO and AI indexing remain fully covered by:
- Meta tags (description, Open Graph, Twitter Card)
- JSON-LD structured data (WebApplication + FAQPage)
- `<noscript>` fallback for non-JS browsers

## Related Issue

Follow-up to #204 / Closes #197

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Emptied `<div id="root">` back to `<div id="root"></div>`, removing 52 lines of static HTML that was visible as a flash before React hydration

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have tested my changes locally
- [x] My code follows the project's architecture patterns