### PR TITLE
feat(address): optimize tx search with eth_getTransactionBySenderAndNonce

### DIFF
--- a/src/config/rethProviders.ts
+++ b/src/config/rethProviders.ts
@@ -1,0 +1,30 @@
+import { ClientFactory, type EthereumClient } from "@openscan/network-connectors";
+
+/**
+ * Hardcoded reth RPC providers for eth_getTransactionBySenderAndNonce support.
+ * These are separate from user-configured RPCs and used only for nonce-based tx lookups.
+ */
+export const RETH_PROVIDER_URLS = [
+  "https://eth-pokt.nodies.app",
+  "https://eth.api.onfinality.io/public",
+  "https://ethereum.rpc.subquery.network/public",
+];
+
+/** Chain ID where nonce-based transaction lookup is available */
+export const NONCE_LOOKUP_CHAIN_ID = 1;
+
+let rethClient: EthereumClient | null = null;
+
+/**
+ * Get a singleton EthereumClient configured with reth providers using race strategy.
+ * Race strategy means the fastest provider wins each call.
+ */
+export function getRethClient(): EthereumClient {
+  if (!rethClient) {
+    rethClient = ClientFactory.createTypedClient(1, {
+      rpcUrls: RETH_PROVIDER_URLS,
+      type: "race",
+    });
+  }
+  return rethClient;
+}

--- a/src/locales/en/address.json
+++ b/src/locales/en/address.json
@@ -183,5 +183,7 @@
   "errorResolvingENS": "Error resolving ENS",
   "unknownError": "Unknown error",
   "failedToFetchAddressData": "Failed to fetch address data",
-  "nonce": "Nonce (Transactions Sent)"
+  "nonce": "Nonce (Transactions Sent)",
+  "fetchingSentTxsByNonce": "Fetching sent transactions ({{current}}/{{total}})...",
+  "searchingReceivedTxs": "Searching for received transactions..."
 }

--- a/src/locales/es/address.json
+++ b/src/locales/es/address.json
@@ -183,5 +183,7 @@
   "errorResolvingENS": "Error al resolver ENS",
   "unknownError": "Error desconocido",
   "failedToFetchAddressData": "No se pudieron obtener los datos de la dirección",
-  "nonce": "Nonce (transacciones enviadas)"
+  "nonce": "Nonce (transacciones enviadas)",
+  "fetchingSentTxsByNonce": "Obteniendo transacciones enviadas ({{current}}/{{total}})...",
+  "searchingReceivedTxs": "Buscando transacciones recibidas..."
 }

--- a/src/services/NonceLookupService.ts
+++ b/src/services/NonceLookupService.ts
@@ -1,0 +1,140 @@
+import type { EthereumClient } from "@openscan/network-connectors";
+import { logger } from "../utils/logger";
+
+/**
+ * Extract data from strategy result, handling both fallback and parallel modes
+ */
+function extractData<T>(data: T | T[] | null | undefined): T | null {
+  if (data === null || data === undefined) return null;
+  if (Array.isArray(data)) return data[0] ?? null;
+  return data;
+}
+
+export interface NonceLookupResult {
+  nonce: number;
+  txHash: string;
+  blockNumber: number;
+}
+
+/**
+ * Service for looking up transactions by sender address + nonce using
+ * the eth_getTransactionBySenderAndNonce RPC method (supported by reth clients).
+ *
+ * This allows O(N) discovery of sent transactions where N = address nonce,
+ * instead of the O(log(blocks) * changes) binary search approach.
+ */
+export class NonceLookupService {
+  private client: EthereumClient;
+  private static readonly BATCH_SIZE = 8;
+
+  constructor(client: EthereumClient) {
+    this.client = client;
+  }
+
+  /**
+   * Probe whether the RPC method is available by making a single test call.
+   * Returns true if the method responds (even with null for unused nonce).
+   */
+  async isAvailable(address: string, nonce: number): Promise<boolean> {
+    try {
+      const nonceHex = `0x${nonce.toString(16)}`;
+      const result = await this.client.execute<string | null>(
+        "eth_getTransactionBySenderAndNonce",
+        [address, nonceHex],
+      );
+      // Method is available if we got a successful response (even if data is null)
+      return result.success;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fetch sent transactions for a range of nonces.
+   * Iterates in batches, calling eth_getTransactionBySenderAndNonce for each nonce.
+   * Individual failures are silently skipped.
+   *
+   * @param address - Sender address
+   * @param startNonce - First nonce to fetch (inclusive)
+   * @param endNonce - Last nonce to fetch (exclusive)
+   * @param signal - Optional AbortSignal for cancellation
+   * @param onBatchComplete - Optional callback after each batch completes
+   * @returns Array of successful lookup results
+   */
+  async fetchSentTransactions(
+    address: string,
+    startNonce: number,
+    endNonce: number,
+    signal?: AbortSignal,
+    onBatchComplete?: (completed: number, total: number) => void,
+  ): Promise<NonceLookupResult[]> {
+    const results: NonceLookupResult[] = [];
+    const total = endNonce - startNonce;
+
+    for (let i = startNonce; i < endNonce; i += NonceLookupService.BATCH_SIZE) {
+      if (signal?.aborted) break;
+
+      const batchEnd = Math.min(i + NonceLookupService.BATCH_SIZE, endNonce);
+      const batchPromises: Promise<NonceLookupResult | null>[] = [];
+
+      for (let nonce = i; nonce < batchEnd; nonce++) {
+        batchPromises.push(this.fetchSingleNonce(address, nonce));
+      }
+
+      const batchResults = await Promise.all(batchPromises);
+      for (const result of batchResults) {
+        if (result) {
+          results.push(result);
+        }
+      }
+
+      onBatchComplete?.(Math.min(batchEnd - startNonce, total), total);
+    }
+
+    return results;
+  }
+
+  /**
+   * Convenience wrapper that fetches only the last N nonces.
+   * Used for limit-based searches (e.g., "last 5 transactions").
+   */
+  async fetchRecentSentTransactions(
+    address: string,
+    currentNonce: number,
+    count: number,
+    signal?: AbortSignal,
+    onBatchComplete?: (completed: number, total: number) => void,
+  ): Promise<NonceLookupResult[]> {
+    const startNonce = Math.max(0, currentNonce - count);
+    return this.fetchSentTransactions(address, startNonce, currentNonce, signal, onBatchComplete);
+  }
+
+  /**
+   * Fetch a single transaction by sender + nonce.
+   * Returns null on failure (tolerates partial failures).
+   */
+  private async fetchSingleNonce(
+    address: string,
+    nonce: number,
+  ): Promise<NonceLookupResult | null> {
+    try {
+      const nonceHex = `0x${nonce.toString(16)}`;
+      const result = await this.client.execute<{ hash: string; blockNumber: string } | null>(
+        "eth_getTransactionBySenderAndNonce",
+        [address, nonceHex],
+      );
+
+      const data = extractData(result.data);
+      if (!data || !data.hash || !data.blockNumber) return null;
+
+      return {
+        nonce,
+        txHash: data.hash,
+        blockNumber: Number.parseInt(data.blockNumber, 16),
+      };
+    } catch (err) {
+      logger.warn(`Nonce lookup failed for ${address} nonce ${nonce}:`, err);
+      return null;
+    }
+  }
+}

--- a/src/services/adapters/EVMAdapter/EVMAdapter.ts
+++ b/src/services/adapters/EVMAdapter/EVMAdapter.ts
@@ -12,6 +12,8 @@ import { extractData } from "../shared/extractData";
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
 import type { EthereumClient, SupportedChainId } from "@openscan/network-connectors";
+import { getRethClient, NONCE_LOOKUP_CHAIN_ID } from "../../../config/rethProviders";
+import { NonceLookupService } from "../../NonceLookupService";
 
 /**
  * EVM-compatible blockchain service
@@ -23,7 +25,14 @@ export class EVMAdapter extends NetworkAdapter {
   constructor(networkId: SupportedChainId | 11155111 | 97 | 31337, client: EthereumClient) {
     super(networkId);
     this.client = client;
-    this.initTxSearch(client);
+
+    if (networkId === NONCE_LOOKUP_CHAIN_ID) {
+      const rethClient = getRethClient();
+      const nonceLookup = new NonceLookupService(rethClient);
+      this.initTxSearch(client, nonceLookup);
+    } else {
+      this.initTxSearch(client);
+    }
   }
 
   protected getClient(): EthereumClient {

--- a/src/services/adapters/NetworkAdapter.ts
+++ b/src/services/adapters/NetworkAdapter.ts
@@ -11,6 +11,7 @@ import type {
 import { logger } from "../../utils/logger";
 import { extractData } from "./shared/extractData";
 import { AddressTransactionSearch } from "../AddressTransactionSearch";
+import type { NonceLookupService } from "../NonceLookupService";
 
 export type BlockTag = "latest" | "earliest" | "pending" | "finalized" | "safe";
 export type BlockNumberOrTag = number | string | BlockTag;
@@ -65,8 +66,8 @@ export abstract class NetworkAdapter {
    * Initialize the transaction search service
    * Call this in subclass constructors to enable binary search tx discovery
    */
-  protected initTxSearch(client: EthereumClient): void {
-    this.txSearch = new AddressTransactionSearch(client);
+  protected initTxSearch(client: EthereumClient, nonceLookup?: NonceLookupService): void {
+    this.txSearch = new AddressTransactionSearch(client, nonceLookup);
   }
 
   /**


### PR DESCRIPTION
## Description

Optimize address transaction search on Ethereum mainnet using reth's `eth_getTransactionBySenderAndNonce` RPC method. This reduces sent-tx discovery from ~50+ binary search RPC calls to exactly N calls (where N = address nonce). Received/internal transactions are found via gap-based binary search between sent tx blocks.

## Related Issue

Closes #211

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **`src/config/rethProviders.ts`** (new): 3 hardcoded reth RPC provider URLs with race strategy, `NONCE_LOOKUP_CHAIN_ID = 1`, singleton `getRethClient()` factory
- **`src/services/NonceLookupService.ts`** (new): Service wrapping `eth_getTransactionBySenderAndNonce` with `isAvailable()`, `fetchSentTransactions()`, and `fetchRecentSentTransactions()`
- **`src/services/AddressTransactionSearch.ts`**: 
  - Optional `NonceLookupService` injection in constructor
  - `searchWithNonceLookup()` with 2-phase approach: nonce lookups → gap search
  - Interleaved progressive delivery (newest-to-oldest) for correct table ordering
  - Exponential narrowing for large gaps to avoid slow archival RPC queries
  - Fixed address case normalization for consistent cache hits across all search paths
- **`src/services/adapters/NetworkAdapter.ts`**: `initTxSearch()` accepts optional `NonceLookupService`
- **`src/services/adapters/EVMAdapter/EVMAdapter.ts`**: Creates `NonceLookupService` with reth client for chain ID 1 only
- **`src/locales/en/address.json`** + **`src/locales/es/address.json`**: 2 new i18n progress message keys

### Key design decisions
- **Separate reth client**: Nonce lookups go to dedicated reth providers (race strategy); receipts/blocks go to user's configured RPC
- **Graceful fallback**: If `eth_getTransactionBySenderAndNonce` is unavailable or fails, binary search runs unchanged
- **No behavior change for non-mainnet**: `NonceLookupService` is only injected for chain ID 1
- **Interleaved delivery**: Segments are processed newest-to-oldest (gap → sent → gap → sent → ...) so each `onTransactionsFound` call appends in correct chronological order
- **Gap search skips pre-first-sent-tx range**: Avoids searching the massive [0, firstSentBlock] gap that would hit non-archival RPCs for ancient blocks

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

Tested manually on Ethereum mainnet addresses with mixed sent/received transactions. Verified correct chronological ordering, progressive table population, and graceful fallback when reth providers are unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)