### PR TITLE
ci(npm): Add missing alpha tag to publish config

### DIFF
--- a/dist-package.template.json
+++ b/dist-package.template.json
@@ -7,7 +7,8 @@
     "url": "git+https://github.com/openscan-explorer/explorer.git"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "alpha"
   },
   "files": ["*"]
 }


### PR DESCRIPTION
## Description

Github actions is failing to publish on NPM. This is because alpha releases requires to specify an explicit tag.

## Related Issue

Closes #220 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Update package.json
## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

<!-- Any additional information that reviewers should know -->
