### PR TITLE
Styles/repalce loading animation

### DIFF
--- a/src/components/LoadingLogo.tsx
+++ b/src/components/LoadingLogo.tsx
@@ -1,0 +1,50 @@
+import type React from "react";
+
+type Props = {
+  size?: number;
+};
+
+const OpenScanCubeLoader: React.FC<Props> = ({ size = 120 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 36 36"
+    xmlns="http://www.w3.org/2000/svg"
+    overflow="visible"
+    aria-label="OpenScan Cube Loader"
+  >
+    <title>OpenScan Cube Loader</title>
+
+    {/* Right face - Dark green */}
+    <g className="cube-breathe-right">
+      <polygon
+        className="cube-rotate-cw"
+        points="20,22 34,14 34,28 20,36"
+        fill="#065743"
+        strokeLinejoin="round"
+      />
+    </g>
+
+    {/* Left face - Hardhat yellow */}
+    <g className="cube-breathe-left">
+      <polygon
+        className="cube-rotate-ccw"
+        points="6,14 20,22 20,36 6,28"
+        fill="#FFF100"
+        strokeLinejoin="round"
+      />
+    </g>
+
+    {/* Top face - Ethereum blue */}
+    <g className="cube-breathe-top">
+      <polygon
+        className="cube-rotate-cw"
+        points="20,6 34,14 20,22 6,14"
+        fill="#627EEA"
+        strokeLinejoin="round"
+      />
+    </g>
+  </svg>
+);
+
+export default OpenScanCubeLoader;

--- a/src/components/common/AIAnalysis/AIAnalysisPanel.tsx
+++ b/src/components/common/AIAnalysis/AIAnalysisPanel.tsx
@@ -3,6 +3,7 @@ import { useEffect, useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
 import { Link } from "react-router-dom";
+import OpenScanCubeLoader from "../../LoadingLogo";
 import { useAIAnalysis } from "../../../hooks/useAIAnalysis";
 import type { AIAnalysisType } from "../../../types";
 
@@ -56,7 +57,7 @@ const AIAnalysisPanel: React.FC<AIAnalysisProps> = ({
           >
             {loading ? (
               <>
-                <span className="ai-analysis-spinner" />
+                <OpenScanCubeLoader size={18} />
                 {t("aiAnalysis.analyzing")}
               </>
             ) : (
@@ -90,6 +91,12 @@ const AIAnalysisPanel: React.FC<AIAnalysisProps> = ({
         aria-hidden={!isOpen}
         style={{ display: isOpen ? "flex" : "none" }}
       >
+        {loading && !result && (
+          <div className="ai-analysis-loading">
+            <OpenScanCubeLoader size={60} />
+          </div>
+        )}
+
         {error && <AIAnalysisError errorType={errorType} onRetry={analyze} />}
 
         {result && (

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,23 +1,15 @@
 import React from "react";
+import OpenScanCubeLoader from "../LoadingLogo";
 
 interface LoaderProps {
   size?: number;
-  color?: string;
   text?: string;
 }
 
-const Loader: React.FC<LoaderProps> = React.memo(({ size = 40, color = "#10b981", text }) => {
+const Loader: React.FC<LoaderProps> = React.memo(({ size = 60, text }) => {
   return (
     <div className="loader-container">
-      <div
-        className="loader-spinner"
-        style={{
-          width: `${size}px`,
-          height: `${size}px`,
-          border: `3px solid rgba(16, 185, 129, 0.2)`,
-          borderTop: `3px solid ${color}`,
-        }}
-      />
+      <OpenScanCubeLoader size={size} />
       {text && <p className="loader-text">{text}</p>}
     </div>
   );

--- a/src/components/common/Loading.tsx
+++ b/src/components/common/Loading.tsx
@@ -1,13 +1,9 @@
 import React from "react";
-import "../../styles/styles.css";
+import OpenScanCubeLoader from "../LoadingLogo";
 
 const Loading = React.memo(() => (
   <div className="loading-container">
-    <div className="wave-loading">
-      <div className="wave"></div>
-      <div className="wave"></div>
-      <div className="wave"></div>
-    </div>
+    <OpenScanCubeLoader size={80} />
   </div>
 ));
 

--- a/src/styles/ai-analysis.css
+++ b/src/styles/ai-analysis.css
@@ -80,21 +80,12 @@
   white-space: pre-line;
 }
 
-/* Loading Spinner */
-.ai-analysis-spinner {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--text-secondary);
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: ai-spin 0.8s linear infinite;
-}
-
-@keyframes ai-spin {
-  to {
-    transform: rotate(360deg);
-  }
+/* Loading State */
+.ai-analysis-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px 0;
 }
 
 /* Result Content */

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1811,6 +1811,65 @@
 	font-weight: 600;
 }
 
+/* Cube Loader */
+.cube-breathe-right {
+	animation: cube-breathe-right 3.14s linear infinite;
+}
+
+.cube-breathe-left {
+	animation: cube-breathe-left 3.14s linear infinite;
+}
+
+.cube-breathe-top {
+	animation: cube-breathe-top 3.14s linear infinite;
+}
+
+.cube-rotate-cw {
+	animation: cube-rotate-cw 7.2s linear infinite;
+	transform-box: view-box;
+	transform-origin: 50% 50%;
+}
+
+.cube-rotate-ccw {
+	animation: cube-rotate-ccw 7.2s linear infinite;
+	transform-box: view-box;
+	transform-origin: 50% 50%;
+}
+
+@keyframes cube-breathe-right {
+	0%   { transform: translate(0px, 0px); }
+	25%  { transform: translate(2.5px, 1px); }
+	50%  { transform: translate(0px, 0px); }
+	75%  { transform: translate(-2.5px, -1px); }
+	100% { transform: translate(0px, 0px); }
+}
+
+@keyframes cube-breathe-left {
+	0%   { transform: translate(0px, 0px); }
+	25%  { transform: translate(-2.5px, 1px); }
+	50%  { transform: translate(0px, 0px); }
+	75%  { transform: translate(2.5px, -1px); }
+	100% { transform: translate(0px, 0px); }
+}
+
+@keyframes cube-breathe-top {
+	0%   { transform: translate(0px, 0px); }
+	25%  { transform: translate(0px, -2.5px); }
+	50%  { transform: translate(0px, 0px); }
+	75%  { transform: translate(0px, 2.5px); }
+	100% { transform: translate(0px, 0px); }
+}
+
+@keyframes cube-rotate-cw {
+	from { transform: rotate(0deg); }
+	to   { transform: rotate(360deg); }
+}
+
+@keyframes cube-rotate-ccw {
+	from { transform: rotate(0deg); }
+	to   { transform: rotate(-360deg); }
+}
+
 /* Loader Component */
 .loader-container {
 	display: flex;
@@ -1818,16 +1877,6 @@
 	justify-content: center;
 	align-items: center;
 	padding: 20px;
-}
-
-.loader-spinner {
-	border-radius: 50%;
-	animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-	0% { transform: rotate(0deg); }
-	100% { transform: rotate(360deg); }
 }
 
 .loader-text {
@@ -2632,14 +2681,6 @@
 	background: linear-gradient(90deg, var(--color-primary), var(--color-primary-muted));
 	border-radius: 4px;
 	transition: width 0.3s ease;
-}
-
-/* Loader component styles */
-.loader-spinner-container {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
 }
 
 /* LongString component styles */

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -648,18 +648,6 @@ a.navbar-logo-dropdown-item {
   min-height: 40vh;
 }
 
-.wave-loading {
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
-}
-
-.wave {
-  width: 12px;
-  height: 12px;
-  margin: 0 6px;
-}
-
 /* Connect Wallet */
 .connect-wallet-content {
   margin: 40px auto 0;
@@ -827,12 +815,6 @@ a.navbar-logo-dropdown-item {
   display: flex;
   flex-direction: column;
   gap: 2px;
-}
-
-.loading-spinner {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
 }
 
 .error-message {
@@ -2557,40 +2539,6 @@ a.navbar-logo-dropdown-item {
   min-height: 40vh;
 }
 
-.wave-loading {
-  display: flex;
-  justify-content: center;
-  align-items: flex-end;
-}
-
-.wave {
-  width: 12px;
-  height: 12px;
-  margin: 0 6px;
-  background: var(--accent);
-  border-radius: 50%;
-  animation: wave 1s infinite ease-in-out;
-}
-
-.wave:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.wave:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes wave {
-
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-
-  50% {
-    transform: translateY(-18px);
-  }
-}
 
 /* Connect Wallet */
 .connect-wallet-content {
@@ -3421,15 +3369,6 @@ a.navbar-logo-dropdown-item {
   flex-shrink: 0;
 }
 
-.loading-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--border-color);
-  border-top: 2px solid var(--accent);
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
-  flex-shrink: 0;
-}
 
 @keyframes spin {
   0% {


### PR DESCRIPTION
## Description

Replace all loading spinners across the app with the branded `OpenScanCubeLoader` — an animated isometric cube using the OpenScan brand colors (Ethereum blue, Hardhat yellow, dark green). The cube animation is driven entirely by CSS keyframes, removing the previous `requestAnimationFrame` implementation and centralising all animation logic in the stylesheet.

## Related Issue

<!-- Link to the related issue (e.g., Closes #123) -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **`src/components/LoadingLogo.tsx`** — Rewrote `OpenScanCubeLoader` as pure JSX (no hooks). Removed `useEffect`, `useRef`, and `requestAnimationFrame`. Added `overflow="visible"` to prevent SVG clipping.
- **`src/components/common/Loader.tsx`** — Replaced CSS circular spinner `<div>` with `<OpenScanCubeLoader>`. Removed the `color` prop. Default size updated from `40` → `60`.
- **`src/components/common/Loading.tsx`** — Replaced wave animation divs with `<OpenScanCubeLoader size={80}>` (used as full-page Suspense fallback).
- **`src/components/common/AIAnalysis/AIAnalysisPanel.tsx`** — Added `<OpenScanCubeLoader size={18}>` inline in the Analyze button during loading, and `<OpenScanCubeLoader size={60}>` in the panel content area while awaiting the AI response.
- **`src/styles/components.css`** — Added CSS keyframe animations for the cube (`cube-breathe-{right,left,top}`, `cube-rotate-{cw,ccw}`). Removed dead `.loader-spinner`, `@keyframes spin` (loader-specific), and `.loader-spinner-container` blocks.
- **`src/styles/ai-analysis.css`** — Replaced `.ai-analysis-spinner` (CSS circle) and `@keyframes ai-spin` with `.ai-analysis-loading` flex container.
- **`src/styles/styles.css`** — Removed dead `.wave-loading`, `.wave`, `@keyframes wave`, and `.loading-spinner` blocks (both light and dark theme variants).

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

- **Breathing** (face separation oscillation): `3.14s` linear cycle —
- **Rotation**: `7.2s` linear cycle

Each face uses a nested `<g>` for the translate (breathe) and the `<polygon>` for the rotation. `transform-box: view-box; transform-origin: 50% 50%` ensures all faces rotate around the SVG centre (18, 18) regardless of the parent translation — matching the original `rotate(angle, 18, 18)` SVG transform behaviour.
