### PR TITLE
fix(navbar): Use base URL for OpenScan home link on GitHub Pages

### DIFF
--- a/src/components/navbar/NavbarLogo.tsx
+++ b/src/components/navbar/NavbarLogo.tsx
@@ -99,8 +99,8 @@ export default function NavbarLogo() {
         window.location.href = baseDomainUrl;
       }
     } else {
-      // If on path, just go to root
-      window.location.href = "/";
+      // If on path, just go to root (respects base path for GitHub Pages)
+      window.location.href = import.meta.env.BASE_URL;
     }
     setIsDropdownOpen(false);
   }, [isOnSubdomain]);


### PR DESCRIPTION
window.location.href was hardcoded to "/" which breaks on GitHub Pages where the app is served from /explorer/.
