### PR TITLE
chore(claude): add no AI attribution rule

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -235,6 +235,13 @@ What outcome or resolution are you looking for?
 Any other details that might be helpful.
 ```
 
+## No AI Attribution
+
+**NEVER include any AI or Claude attribution** in commits, PRs, issues, or any generated content. This includes:
+- No `Co-Authored-By: Claude` in commit messages
+- No "Generated with Claude Code" in PR bodies
+- No AI-related footers, badges, or mentions anywhere
+
 ## Creating PRs with Claude
 
 **IMPORTANT: Always use the PR template when creating pull requests.**


### PR DESCRIPTION
## Description

Adds a rule to `.claude/rules/workflow.md` to prevent any AI/Claude attribution from appearing in commits, PRs, issues, or any generated content.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Other (please describe): Developer tooling configuration

## Changes Made

- Added "No AI Attribution" section to `.claude/rules/workflow.md` prohibiting `Co-Authored-By`, "Generated with Claude Code", and any other AI-related footers or mentions

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns