### PR TITLE
feat(transaction): make event logs collapsible

### DIFF
--- a/src/components/pages/evm/tx/TransactionDisplay.tsx
+++ b/src/components/pages/evm/tx/TransactionDisplay.tsx
@@ -72,6 +72,7 @@ const TransactionDisplay: React.FC<TransactionDisplayProps> = React.memo(
     const [callTargetTokenListMatch, setCallTargetTokenListMatch] = useState<TokenListItem | null>(
       null,
     );
+    const [showEventLogs, setShowEventLogs] = useState(false);
     const [showTrace, setShowTrace] = useState(false);
     const [traceData, setTraceData] = useState<TraceResult | null>(null);
     // biome-ignore lint/suspicious/noExplicitAny: <TODO>
@@ -771,6 +772,172 @@ const TransactionDisplay: React.FC<TransactionDisplayProps> = React.memo(
               </div>
             )}
 
+            {/* Event Logs Section - Collapsible, closed by default */}
+            {transaction.receipt && transaction.receipt.logs.length > 0 && (
+              <div className="tx-section event-logs-section">
+                <button
+                  type="button"
+                  className="tx-section-header tx-section-header-toggle"
+                  onClick={() => setShowEventLogs(!showEventLogs)}
+                >
+                  <span className="tx-section-title">
+                    {t("eventLogs")} ({transaction.receipt.logs.length})
+                  </span>
+                  <span className="tx-section-chevron">{showEventLogs ? "▲" : "▼"}</span>
+                </button>
+                {showEventLogs && (
+                  <div className="tx-logs">
+                    {/** biome-ignore lint/suspicious/noExplicitAny: <TODO> */}
+                    {transaction.receipt.logs.map((log: any, index: number) => {
+                      // Try ABI-based decoding first if log is from tx.to and we have contract data
+                      let decoded: DecodedEvent | null = null;
+                      let abiDecoded: DecodedInput | null = null;
+
+                      const isFromTxRecipient =
+                        transaction.to &&
+                        log.address &&
+                        log.address.toLowerCase() === transaction.to.toLowerCase();
+
+                      if (isFromTxRecipient && contractData?.abi && log.topics) {
+                        abiDecoded = decodeEventWithAbi(
+                          log.topics,
+                          log.data || "0x",
+                          contractData.abi,
+                        );
+                      }
+
+                      // Fallback to standard event lookup
+                      if (!abiDecoded && log.topics) {
+                        decoded = decodeEventLog(log.topics, log.data || "0x");
+                      }
+
+                      // Determine which decoded data to display
+                      const hasDecoded = abiDecoded || decoded;
+                      const displayName = abiDecoded?.functionName || decoded?.name;
+                      const displaySignature = abiDecoded?.signature || decoded?.fullSignature;
+                      const displayParams = abiDecoded?.params || decoded?.params || [];
+
+                      return (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: <TODO>
+                        <div key={index} className="tx-log">
+                          <div className="tx-log-index">{index}</div>
+                          <div className="tx-log-content">
+                            {/* Decoded Event Header */}
+                            {hasDecoded && (
+                              <div className="tx-log-decoded">
+                                <span
+                                  className="tx-event-badge"
+                                  style={
+                                    {
+                                      "--event-color": abiDecoded
+                                        ? "#10b981"
+                                        : getEventTypeColor(decoded?.type || ""),
+                                    } as React.CSSProperties
+                                  }
+                                >
+                                  {displayName}
+                                </span>
+                                <span
+                                  className="tx-event-signature"
+                                  title={decoded?.description || displaySignature}
+                                >
+                                  {displaySignature}
+                                </span>
+                                {abiDecoded && (
+                                  <span className="tx-abi-badge" title="Decoded using contract ABI">
+                                    {t("logsAbi")}
+                                  </span>
+                                )}
+                              </div>
+                            )}
+
+                            {/* Address */}
+                            <div className="tx-log-row">
+                              <span className="tx-log-label">{t("logsAddress")}</span>
+                              <span className="tx-log-value tx-mono">
+                                {networkId ? (
+                                  <Link
+                                    to={`/${networkId}/address/${log.address}`}
+                                    className="link-accent"
+                                  >
+                                    {log.address}
+                                  </Link>
+                                ) : (
+                                  log.address
+                                )}
+                              </span>
+                            </div>
+
+                            {/* Decoded Parameters */}
+                            {displayParams.length > 0 && (
+                              <div className="tx-log-row tx-log-params">
+                                <span className="tx-log-label">{t("logsDecoded")}</span>
+                                <div className="tx-log-value">
+                                  {displayParams.map((param, i) => (
+                                    // biome-ignore lint/suspicious/noArrayIndexKey: <TODO>
+                                    <div key={i} className="tx-decoded-param">
+                                      <span className="tx-param-name">{param.name}</span>
+                                      <span className="tx-param-type">({param.type})</span>
+                                      <span
+                                        className={`tx-param-value ${param.type === "address" ? "tx-mono" : ""}`}
+                                      >
+                                        {param.type === "address" && networkId ? (
+                                          <Link
+                                            to={`/${networkId}/address/${param.value}`}
+                                            className="link-accent"
+                                          >
+                                            {param.value}
+                                          </Link>
+                                        ) : (
+                                          formatDecodedValue(param.value, param.type)
+                                        )}
+                                      </span>
+                                      {param.indexed && (
+                                        <span className="tx-param-indexed">{t("logsIndexed")}</span>
+                                      )}
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+
+                            {/* Raw Topics (collapsed if decoded) */}
+                            {log.topics && log.topics.length > 0 && (
+                              <div className="tx-log-row tx-log-topics">
+                                <span className="tx-log-label">
+                                  {hasDecoded ? t("logsRawTopics") : t("logsTopics")}
+                                </span>
+                                <div className="tx-log-value">
+                                  {log.topics.map((topic: string, i: number) => (
+                                    <div key={topic} className="tx-topic">
+                                      <span className="tx-topic-index">[{i}]</span>
+                                      <code className="tx-topic-value">{topic}</code>
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+
+                            {/* Raw Data */}
+                            {log.data && log.data !== "0x" && (
+                              <div className="tx-log-row">
+                                <span className="tx-log-label">
+                                  {hasDecoded ? t("logsRawData") : t("logsData")}
+                                </span>
+                                <div className="tx-log-value">
+                                  <code className="tx-log-data">{log.data}</code>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Full-width rows: long content */}
             {/* Input Data */}
             <div className="tx-row tx-row-vertical">
@@ -822,161 +989,6 @@ const TransactionDisplay: React.FC<TransactionDisplayProps> = React.memo(
               </div>
             )}
           </div>
-
-          {/* Event Logs Section - Always visible */}
-          {transaction.receipt && transaction.receipt.logs.length > 0 && (
-            <div className="tx-section">
-              <div className="tx-section-header">
-                <span className="tx-section-title">
-                  {t("eventLogs")} ({transaction.receipt.logs.length})
-                </span>
-              </div>
-              <div className="tx-logs">
-                {/** biome-ignore lint/suspicious/noExplicitAny: <TODO> */}
-                {transaction.receipt.logs.map((log: any, index: number) => {
-                  // Try ABI-based decoding first if log is from tx.to and we have contract data
-                  let decoded: DecodedEvent | null = null;
-                  let abiDecoded: DecodedInput | null = null;
-
-                  const isFromTxRecipient =
-                    transaction.to &&
-                    log.address &&
-                    log.address.toLowerCase() === transaction.to.toLowerCase();
-
-                  if (isFromTxRecipient && contractData?.abi && log.topics) {
-                    abiDecoded = decodeEventWithAbi(log.topics, log.data || "0x", contractData.abi);
-                  }
-
-                  // Fallback to standard event lookup
-                  if (!abiDecoded && log.topics) {
-                    decoded = decodeEventLog(log.topics, log.data || "0x");
-                  }
-
-                  // Determine which decoded data to display
-                  const hasDecoded = abiDecoded || decoded;
-                  const displayName = abiDecoded?.functionName || decoded?.name;
-                  const displaySignature = abiDecoded?.signature || decoded?.fullSignature;
-                  const displayParams = abiDecoded?.params || decoded?.params || [];
-
-                  return (
-                    // biome-ignore lint/suspicious/noArrayIndexKey: <TODO>
-                    <div key={index} className="tx-log">
-                      <div className="tx-log-index">{index}</div>
-                      <div className="tx-log-content">
-                        {/* Decoded Event Header */}
-                        {hasDecoded && (
-                          <div className="tx-log-decoded">
-                            <span
-                              className="tx-event-badge"
-                              style={
-                                {
-                                  "--event-color": abiDecoded
-                                    ? "#10b981"
-                                    : getEventTypeColor(decoded?.type || ""),
-                                } as React.CSSProperties
-                              }
-                            >
-                              {displayName}
-                            </span>
-                            <span
-                              className="tx-event-signature"
-                              title={decoded?.description || displaySignature}
-                            >
-                              {displaySignature}
-                            </span>
-                            {abiDecoded && (
-                              <span className="tx-abi-badge" title="Decoded using contract ABI">
-                                {t("logsAbi")}
-                              </span>
-                            )}
-                          </div>
-                        )}
-
-                        {/* Address */}
-                        <div className="tx-log-row">
-                          <span className="tx-log-label">{t("logsAddress")}</span>
-                          <span className="tx-log-value tx-mono">
-                            {networkId ? (
-                              <Link
-                                to={`/${networkId}/address/${log.address}`}
-                                className="link-accent"
-                              >
-                                {log.address}
-                              </Link>
-                            ) : (
-                              log.address
-                            )}
-                          </span>
-                        </div>
-
-                        {/* Decoded Parameters */}
-                        {displayParams.length > 0 && (
-                          <div className="tx-log-row tx-log-params">
-                            <span className="tx-log-label">{t("logsDecoded")}</span>
-                            <div className="tx-log-value">
-                              {displayParams.map((param, i) => (
-                                // biome-ignore lint/suspicious/noArrayIndexKey: <TODO>
-                                <div key={i} className="tx-decoded-param">
-                                  <span className="tx-param-name">{param.name}</span>
-                                  <span className="tx-param-type">({param.type})</span>
-                                  <span
-                                    className={`tx-param-value ${param.type === "address" ? "tx-mono" : ""}`}
-                                  >
-                                    {param.type === "address" && networkId ? (
-                                      <Link
-                                        to={`/${networkId}/address/${param.value}`}
-                                        className="link-accent"
-                                      >
-                                        {param.value}
-                                      </Link>
-                                    ) : (
-                                      formatDecodedValue(param.value, param.type)
-                                    )}
-                                  </span>
-                                  {param.indexed && (
-                                    <span className="tx-param-indexed">{t("logsIndexed")}</span>
-                                  )}
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Raw Topics (collapsed if decoded) */}
-                        {log.topics && log.topics.length > 0 && (
-                          <div className="tx-log-row tx-log-topics">
-                            <span className="tx-log-label">
-                              {hasDecoded ? t("logsRawTopics") : t("logsTopics")}
-                            </span>
-                            <div className="tx-log-value">
-                              {log.topics.map((topic: string, i: number) => (
-                                <div key={topic} className="tx-topic">
-                                  <span className="tx-topic-index">[{i}]</span>
-                                  <code className="tx-topic-value">{topic}</code>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-
-                        {/* Raw Data */}
-                        {log.data && log.data !== "0x" && (
-                          <div className="tx-log-row">
-                            <span className="tx-log-label">
-                              {hasDecoded ? t("logsRawData") : t("logsData")}
-                            </span>
-                            <div className="tx-log-value">
-                              <code className="tx-log-data">{log.data}</code>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
 
           {/* Debug Trace Section (Localhost Only) */}
           {isTraceAvailable && (

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -447,6 +447,31 @@
 	border-bottom: 1px solid var(--color-primary-alpha-15);
 }
 
+button.tx-section-header-toggle {
+	width: 100%;
+	border: none;
+	font: inherit;
+	color: inherit;
+	cursor: pointer;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	user-select: none;
+}
+
+.tx-section-header-toggle:hover {
+	background: var(--color-primary-alpha-15);
+}
+
+.tx-section-chevron {
+	font-size: 0.75rem;
+	color: var(--text-secondary);
+}
+
+.event-logs-section {
+	margin-top: 16px;
+}
+
 /* ==========================================================================
    TITLES - Section title classes
    All section titles share base typography


### PR DESCRIPTION
## Description

Make the Event Logs section on the transaction detail page collapsible (closed by default) and reposition it above the Input Data section for better information hierarchy.

## Related Issue

Closes #234

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added a collapsible toggle (button with chevron indicator) to the Event Logs section header
- Event Logs section is now **collapsed by default**, reducing visual clutter for transactions with many events
- Moved Event Logs section above Input Data for better information hierarchy
- Added CSS styles for the toggle button, hover state, and chevron indicator
- Used semantic `<button>` element for accessibility

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

- No new i18n keys needed — the existing `t("eventLogs")` key and unicode chevron symbols (▲/▼) are used
- Follows existing toggle patterns in TransactionDisplay (e.g. Debug Trace section)