### PR TITLE
ci(audit): add npm audit workflow for PRs to dev and main

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Run audit
         run: npm run audit


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that runs `npm run audit` on every pull request targeting `dev` or `main` branches.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `.github/workflows/audit.yml` that:
  - Triggers on PRs to `dev` and `main`
  - Checks out the repo, sets up Node 22, and runs `npm run audit`
  - Uses the existing `scripts/audit.sh` which generates a temporary `package-lock.json`, runs `npm audit`, and cleans up

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

The workflow reuses the existing `npm run audit` script (`scripts/audit.sh`) which generates a temporary `package-lock.json` for audit compatibility with the bun-based project.