### PR TITLE
chore: bump version from 1.2.2-alpha to 1.2.3-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "openscan",
-	"version": "1.2.2-alpha",
+	"version": "1.2.3-alpha",
 	"private": true,
 	"type": "module",
 	"packageManager": "bun@1.1.0",


### PR DESCRIPTION
Bumps version in `package.json` from `1.2.2-alpha` to `1.2.3-alpha`.