### PR TITLE
fix: pre-release fixes for v1.2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+package-lock.json
 .pnp
 .pnp.js
 
@@ -53,6 +54,10 @@ ehthumbs.db
 
 # Dev files
 src/config/dev.json
+
+# Claude Code (local-only files)
+.claude/plans/
+.claude/settings.local.json
 
 # Playwright
 /test-results/

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -35,7 +35,10 @@
 /* Note: No display property set here to preserve natural element display (e.g., table-cell for td/th) */
 
 /* Show only on mobile (hide on tablet+) */
-.show-mobile {
+.show-mobile,
+.show-mobile-flex,
+.show-mobile-inline,
+.show-mobile-inline-flex {
   display: none;
 }
 


### PR DESCRIPTION
## Description

Small fixes before the v1.2.3 release.

## Changes Made

- **fix(css)**: Address hash duplicated on desktop — `.show-mobile-flex`, `.show-mobile-inline`, and `.show-mobile-inline-flex` were missing a default `display: none`, causing both the desktop and mobile spans to render simultaneously on the address page
- **chore**: Ignore `package-lock.json` (project uses Bun) and `.claude/plans/` in `.gitignore`

## Type of Change
- [x] Bug fix

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have tested my changes locally