### PR TITLE
fix(bitcoin): decode and display OP_RETURN payload in transaction outputs

### DIFF
--- a/src/components/pages/bitcoin/BitcoinTransactionDisplay.tsx
+++ b/src/components/pages/bitcoin/BitcoinTransactionDisplay.tsx
@@ -15,11 +15,27 @@ import {
 import {
   calculateTotalInput,
   calculateTotalOutput,
+  decodeOpReturnData,
   hasWitness,
   isCoinbaseTransaction,
   isRBFEnabled,
 } from "../../../utils/bitcoinUtils";
 import AIAnalysisPanel from "../../common/AIAnalysis/AIAnalysisPanel";
+
+const OpReturnDisplay: React.FC<{ hex: string }> = ({ hex }) => {
+  const decoded = useMemo(() => decodeOpReturnData(hex), [hex]);
+  return (
+    <div className="btc-op-return">
+      <span className="btc-op-return-label">OP_RETURN</span>
+      {decoded.text ? (
+        <span className="btc-op-return-text">{decoded.text}</span>
+      ) : (
+        <span className="btc-op-return-hex tx-mono">{decoded.hex}</span>
+      )}
+      <CopyButton value={decoded.text || decoded.hex} />
+    </div>
+  );
+};
 
 interface BitcoinTransactionDisplayProps {
   transaction: BitcoinTransaction;
@@ -422,12 +438,10 @@ const BitcoinTransactionDisplay: React.FC<BitcoinTransactionDisplayProps> = Reac
                             )}
                             <CopyButton value={output.scriptPubKey.address} />
                           </>
+                        ) : output.scriptPubKey.type === "nulldata" ? (
+                          <OpReturnDisplay hex={output.scriptPubKey.hex} />
                         ) : (
-                          <span className="tx-mono text-muted">
-                            {output.scriptPubKey.type === "nulldata"
-                              ? "OP_RETURN (Data)"
-                              : output.scriptPubKey.type}
-                          </span>
+                          <span className="tx-mono text-muted">{output.scriptPubKey.type}</span>
                         )}
                       </div>
                       <div className="btc-io-details">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -7132,6 +7132,33 @@ button.tx-section-header-toggle {
 	font-style: italic;
 }
 
+.btc-op-return {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	flex-wrap: wrap;
+	word-break: break-all;
+}
+
+.btc-op-return-label {
+	font-weight: 600;
+	font-size: 0.8rem;
+	color: var(--text-secondary);
+	background: var(--overlay-light-5);
+	padding: 2px 6px;
+	border-radius: 4px;
+	white-space: nowrap;
+}
+
+.btc-op-return-text {
+	color: var(--text-primary);
+}
+
+.btc-op-return-hex {
+	color: var(--text-secondary);
+	font-size: 0.85rem;
+}
+
 .btc-io-details {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/utils/bitcoinUtils.ts
+++ b/src/utils/bitcoinUtils.ts
@@ -60,3 +60,73 @@ export function hasWitness(tx: BitcoinTransaction): boolean {
 export function isCoinbaseTransaction(tx: BitcoinTransaction): boolean {
   return tx.vin.length === 1 && !tx.vin[0]?.txid;
 }
+
+/**
+ * Decode OP_RETURN payload from scriptPubKey hex.
+ * Script format: 6a [push opcodes] <data>
+ * Returns the decoded UTF-8 string if valid, otherwise the raw hex data.
+ */
+export function decodeOpReturnData(hex: string): { text: string | null; hex: string } {
+  // Strip the OP_RETURN opcode (0x6a) prefix
+  if (!hex.startsWith("6a") || hex.length < 4) {
+    return { text: null, hex };
+  }
+
+  let offset = 2; // skip OP_RETURN (6a)
+  const dataChunks: string[] = [];
+
+  while (offset < hex.length) {
+    const opByte = parseInt(hex.slice(offset, offset + 2), 16);
+    if (Number.isNaN(opByte)) break;
+    offset += 2;
+
+    let pushLen: number;
+    if (opByte >= 0x01 && opByte <= 0x4b) {
+      // Direct push: opByte is the number of bytes to push
+      pushLen = opByte;
+    } else if (opByte === 0x4c) {
+      // OP_PUSHDATA1: next 1 byte is the length
+      pushLen = parseInt(hex.slice(offset, offset + 2), 16);
+      if (Number.isNaN(pushLen)) break;
+      offset += 2;
+    } else if (opByte === 0x4d) {
+      // OP_PUSHDATA2: next 2 bytes (little-endian) is the length
+      const lo = parseInt(hex.slice(offset, offset + 2), 16);
+      const hi = parseInt(hex.slice(offset + 2, offset + 4), 16);
+      if (Number.isNaN(lo) || Number.isNaN(hi)) break;
+      pushLen = lo | (hi << 8);
+      offset += 4;
+    } else {
+      // Unknown opcode or OP_0, skip rest
+      break;
+    }
+
+    const chunkHex = hex.slice(offset, offset + pushLen * 2);
+    if (chunkHex.length < pushLen * 2) break;
+    dataChunks.push(chunkHex);
+    offset += pushLen * 2;
+  }
+
+  const rawHex = dataChunks.join("");
+  if (!rawHex) {
+    return { text: null, hex };
+  }
+
+  // Try to decode as UTF-8
+  try {
+    const bytes = new Uint8Array(rawHex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = parseInt(rawHex.slice(i * 2, i * 2 + 2), 16);
+    }
+    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    // Check if it has enough printable characters to be meaningful text
+    const printable = decoded.replace(/[^\x20-\x7E\u00A0-\uFFFF]/g, "");
+    if (printable.length >= decoded.length * 0.5) {
+      return { text: decoded, hex: rawHex };
+    }
+  } catch {
+    // Not valid UTF-8
+  }
+
+  return { text: null, hex: rawHex };
+}


### PR DESCRIPTION
## Description
OP_RETURN outputs in Bitcoin transactions were shown as a static "OP_RETURN (Data)" label without displaying the actual payload data. This fix decodes the scriptPubKey hex and renders the content.

## Related Issue
Closes #294

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other

## Changes Made
- Added `decodeOpReturnData()` utility in `bitcoinUtils.ts` that parses OP_RETURN script hex, handling direct push (0x01–0x4b), OP_PUSHDATA1 (0x4c), and OP_PUSHDATA2 (0x4d) opcodes
- Attempts UTF-8 decoding of the payload; falls back to raw hex display if not valid text
- Added `OpReturnDisplay` component in `BitcoinTransactionDisplay.tsx` that renders an "OP_RETURN" label badge alongside the decoded text or hex, with a copy button
- Added CSS styles for the OP_RETURN display (`.btc-op-return`, `.btc-op-return-label`, `.btc-op-return-text`, `.btc-op-return-hex`)

## Screenshots (if applicable)
N/A — test with tx `1441eb6656360b45d70ad77f79054426a25f6f3c2ca738d19fae0862888210ee` on Bitcoin mainnet, which should display: `{(₿)} Bitcoin.ar en bloque 940000 by @MatheyBTC`

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes
The decoder handles the standard Bitcoin script push data opcodes. Non-OP_RETURN outputs remain completely unchanged.