### PR TITLE
fix(nav): Super User toggle button layout shift

### DIFF
--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -110,47 +110,6 @@ const Navbar = () => {
             <ul className="hide-mobile">
               {isSuperUser && (
                 <li>
-                  <span className="navbar-super-user-badge">{t("nav.superUserBadge")}</span>
-                </li>
-              )}
-              <li>
-                <button
-                  type="button"
-                  onClick={toggleSuperUserMode}
-                  className={`navbar-toggle-btn ${isSuperUser ? "navbar-toggle-active" : ""}`}
-                  aria-label={isSuperUser ? t("nav.disableSuperUser") : t("nav.enableSuperUser")}
-                  title={isSuperUser ? "Disable Super User Mode" : "Enable Super User Mode"}
-                >
-                  <svg
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                  >
-                    <title>Super User Mode</title>
-                    <polyline
-                      points="4 17 10 11 4 5"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <line
-                      x1="12"
-                      y1="19"
-                      x2="20"
-                      y2="19"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                </button>
-              </li>
-              {isSuperUser && (
-                <li>
                   <button
                     type="button"
                     onClick={() => navigate("/devtools")}
@@ -265,6 +224,42 @@ const Navbar = () => {
                       />
                     </svg>
                   )}
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  onClick={toggleSuperUserMode}
+                  className={`navbar-toggle-btn ${isSuperUser ? "navbar-toggle-active" : ""}`}
+                  aria-label={isSuperUser ? t("nav.disableSuperUser") : t("nav.enableSuperUser")}
+                  title={isSuperUser ? "Disable Super User Mode" : "Enable Super User Mode"}
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <title>Super User Mode</title>
+                    <polyline
+                      points="4 17 10 11 4 5"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <line
+                      x1="12"
+                      y1="19"
+                      x2="20"
+                      y2="19"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                    />
+                  </svg>
                 </button>
               </li>
               <li>


### PR DESCRIPTION
## Description

Fix the Super User mode toggle button shifting position when enabled/disabled, and reorder the DevTools button placement.

## Related Issue

Fixes #298

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Moved Super User toggle to a fixed position in the navbar icon list (between Theme and Settings) — it always renders regardless of state, preventing layout shift
- Removed the conditional "SUPER USER" badge that caused elements to shift when toggling
- DevTools button now appears to the **left** of all fixed icons when Super User mode is enabled
- No changes to mobile menu layout

**Desktop icon order:** DevTools (conditional) → Theme → Super User toggle → Settings

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] Tested toggling Super User mode on/off — no position shift
- [x] Tested DevTools button appears to the left of Super User toggle
- [x] My code follows the project's architecture patterns