### PR TITLE
feat(rpc): auto-sync RPCs every 24h & Alchemy Bitcoin endpoints

### DIFF
--- a/src/components/pages/settings/index.tsx
+++ b/src/components/pages/settings/index.tsx
@@ -46,6 +46,12 @@ const ALCHEMY_NETWORKS: Record<number, string> = {
   8453: "base-mainnet",
 };
 
+// Alchemy Bitcoin networks keyed by CAIP-2 networkId
+const ALCHEMY_BTC_NETWORKS: Record<string, string> = {
+  "bip122:000000000019d6689c085ae165831e93": "btc-mainnet",
+  "bip122:00000000da84f2bafbbc53dee25a72ae": "btc-testnet",
+};
+
 const getInfuraUrl = (chainId: number, apiKey: string): string | null => {
   const slug = INFURA_NETWORKS[chainId];
   return slug ? `https://${slug}.infura.io/v3/${apiKey}` : null;
@@ -53,6 +59,11 @@ const getInfuraUrl = (chainId: number, apiKey: string): string | null => {
 
 const getAlchemyUrl = (chainId: number, apiKey: string): string | null => {
   const slug = ALCHEMY_NETWORKS[chainId];
+  return slug ? `https://${slug}.g.alchemy.com/v2/${apiKey}` : null;
+};
+
+const getAlchemyBtcUrl = (networkId: string, apiKey: string): string | null => {
+  const slug = ALCHEMY_BTC_NETWORKS[networkId];
   return slug ? `https://${slug}.g.alchemy.com/v2/${apiKey}` : null;
 };
 
@@ -139,9 +150,9 @@ const Settings: React.FC = () => {
     setPersistentCacheBytes(0);
     setCacheCleared(true);
     setTimeout(() => setCacheCleared(false), 3000);
-    // Reset sync flag so RPCs are re-sorted on next load
-    updateSettings({ rpcsSynced: false });
-  }, [updateSettings]);
+    // Clear RPC sync timestamp so RPCs are re-sorted on next load
+    localStorage.removeItem("openScan_lastRpcSyncTime");
+  }, []);
 
   // Clear all site data (like browser dev tools)
   const clearSiteData = useCallback(async () => {
@@ -463,6 +474,27 @@ const Settings: React.FC = () => {
       }
 
       parsed[networkId] = urls;
+    }
+
+    // Handle Alchemy Bitcoin endpoints
+    for (const btcNetworkId of Object.keys(ALCHEMY_BTC_NETWORKS)) {
+      let urls: string[] = (parsed[btcNetworkId] as string[]) || [];
+
+      const oldAlchemyBtcUrl = prevAlchemyKey
+        ? getAlchemyBtcUrl(btcNetworkId, prevAlchemyKey)
+        : null;
+      const newAlchemyBtcUrl = localApiKeys.alchemy
+        ? getAlchemyBtcUrl(btcNetworkId, localApiKeys.alchemy)
+        : null;
+
+      if (oldAlchemyBtcUrl && oldAlchemyBtcUrl !== newAlchemyBtcUrl) {
+        urls = urls.filter((u) => u !== oldAlchemyBtcUrl);
+      }
+      if (newAlchemyBtcUrl && !urls.includes(newAlchemyBtcUrl)) {
+        urls = [newAlchemyBtcUrl, ...urls];
+      }
+
+      parsed[btcNetworkId] = urls;
     }
 
     // Save API keys to settings

--- a/src/hooks/useRpcAutoSync.ts
+++ b/src/hooks/useRpcAutoSync.ts
@@ -1,16 +1,28 @@
 import { useContext, useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { AppContext } from "../context/AppContext";
-import { useSettings } from "../context/SettingsContext";
 import { logger } from "../utils/logger";
 import { autoSyncRpcs } from "../utils/rpcAutoSync";
 import { saveRpcUrlsToStorage } from "../utils/rpcStorage";
 
 const ROUTE_SETTLE_MS = 1500;
+const SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const STORAGE_KEY = "openScan_lastRpcSyncTime";
+
+function isSyncNeeded(): boolean {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) return true;
+
+  const elapsed = Date.now() - Number(stored);
+  return elapsed >= SYNC_INTERVAL_MS;
+}
+
+function saveSyncTimestamp(): void {
+  localStorage.setItem(STORAGE_KEY, String(Date.now()));
+}
 
 export function useRpcAutoSync(): void {
   const { rpcUrls, networksLoading, networks } = useContext(AppContext);
-  const { settings, updateSettings } = useSettings();
   const location = useLocation();
   const syncedRef = useRef(false);
   const timerRef = useRef<number | null>(null);
@@ -18,7 +30,7 @@ export function useRpcAutoSync(): void {
   // biome-ignore lint/correctness/useExhaustiveDependencies: location.key is intentional — resets the debounce timer on every navigation event
   useEffect(() => {
     if (networksLoading) return;
-    if (settings.rpcsSynced) return;
+    if (!isSyncNeeded()) return;
     if (Object.keys(rpcUrls).length === 0) return;
     if (syncedRef.current) return;
 
@@ -33,7 +45,7 @@ export function useRpcAutoSync(): void {
       autoSyncRpcs(rpcUrls, networks)
         .then((sorted) => {
           saveRpcUrlsToStorage(sorted);
-          updateSettings({ rpcsSynced: true });
+          saveSyncTimestamp();
           logger.info("Auto-sync RPCs completed, sorted order saved for next load");
         })
         .catch(() => {
@@ -46,5 +58,5 @@ export function useRpcAutoSync(): void {
         window.clearTimeout(timerRef.current);
       }
     };
-  }, [location.key, networksLoading, settings.rpcsSynced, rpcUrls, networks, updateSettings]);
+  }, [location.key, networksLoading, rpcUrls, networks]);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -485,7 +485,6 @@ export interface UserSettings {
   isSuperUser?: boolean;
   promptVersion?: PromptVersion;
   persistentCacheSizeMB?: number;
-  rpcsSynced?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

Two RPC improvements:
1. **Auto-sync every 24 hours** — RPCs are re-tested and sorted on app start if 24+ hours have passed since the last sync
2. **Alchemy Bitcoin endpoints** — Saving an Alchemy API key now auto-adds Bitcoin mainnet and testnet4 RPCs

## Related Issue

Closes #295, Closes #293

## Type of Change

- [x] New feature

## Changes Made

### Auto-sync RPCs every 24h (#295)
- Replaced `rpcsSynced` boolean flag with `openScan_lastRpcSyncTime` timestamp in localStorage
- `isSyncNeeded()` checks if 24+ hours elapsed or no timestamp exists (first-time user)
- Removed `rpcsSynced` from `UserSettings` type — no longer needed
- Cache clear now removes the timestamp instead of setting a flag
- Removed `useSettings` dependency from the hook (simpler, no settings writes)

### Alchemy Bitcoin endpoints (#293)
- Added `ALCHEMY_BTC_NETWORKS` mapping for Bitcoin mainnet (`bip122:000000000019d6689c085ae165831e93`) and testnet4 (`bip122:00000000da84f2bafbbc53dee25a72ae`)
- Added `getAlchemyBtcUrl()` helper
- Auto-add/remove/update logic mirrors existing EVM behavior: replaces old URL on key change, removes on key clear, avoids duplicates

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] My code follows the project's architecture patterns