### PR TITLE
fix(address): Sourcify V2 verified contracts shown as not verified

### DIFF
--- a/src/hooks/useSourcify.ts
+++ b/src/hooks/useSourcify.ts
@@ -75,7 +75,7 @@ interface SourcifyV2Raw {
 
 function normalizeMatch(raw?: string): "perfect" | "partial" | null {
   if (!raw) return null;
-  if (raw === "exact_match" || raw === "perfect") return "perfect";
+  if (raw === "match" || raw === "exact_match" || raw === "perfect") return "perfect";
   if (raw.includes("partial")) return "partial";
   return null;
 }


### PR DESCRIPTION
## Description

Sourcify-verified contracts (e.g. USDT, Uniswap V3 Factory) were incorrectly displayed as "not verified" because the `normalizeMatch()` function in `useSourcify.ts` did not recognize the Sourcify V2 API's `"match"` value as a valid verification state.

## Related Issue

Fixes #312

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `"match"` to the recognized values in `normalizeMatch()` — the Sourcify V2 API returns `"match": "match"` for verified contracts, but the function only checked for `"exact_match"` and `"perfect"`

## Root Cause

The Sourcify V2 API returns `{ "match": "match" }` for verified contracts. The `normalizeMatch()` function mapped this to `null` (unverified) because it only recognized `"exact_match"`, `"perfect"`, and strings containing `"partial"`. This caused `isVerified` to be `false` for all Sourcify-verified contracts.

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns