### PR TITLE
fix(ci): fail audit on moderate+ severity

### DIFF
--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -8,7 +8,7 @@ echo "Generating package-lock.json..."
 npm i --package-lock-only --silent
 
 echo "Running npm audit..."
-npm audit "$@" || true
+npm audit --audit-level=moderate "$@"
 
 echo "Cleaning up..."
 rm -f package-lock.json


### PR DESCRIPTION
## Description
The CI audit script was using `|| true` which made it always pass regardless of findings. This change makes `npm audit` fail the workflow when moderate, high, or critical vulnerabilities are found.

## Related Issue
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made
- Changed `npm audit "$@" || true` to `npm audit --audit-level=moderate "$@"` in `scripts/audit.sh`

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have tested my changes locally
- [x] My code follows the project's architecture patterns

## Additional Notes
This means the audit workflow will now correctly block PRs that introduce moderate+ severity vulnerabilities.