### PR TITLE
feat(tx): decode UTF-8 text in transaction input data

### DIFF
--- a/src/components/pages/evm/tx/analyser/InputDataTab.tsx
+++ b/src/components/pages/evm/tx/analyser/InputDataTab.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import type { ContractInfo } from "../../../../../utils/contractLookup";
 import { formatDecodedValue } from "../../../../../utils/eventDecoder";
-import { type DecodedInput, decodeFunctionCall } from "../../../../../utils/inputDecoder";
+import {
+  type DecodedInput,
+  decodeFunctionCall,
+  tryDecodeUtf8,
+} from "../../../../../utils/inputDecoder";
 
 const InputDataTab: React.FC<{
   inputData: string;
@@ -23,6 +27,9 @@ const InputDataTab: React.FC<{
       if (!enriched?.abi) return null;
       return decodeFunctionCall(inputData, enriched.abi);
     })();
+
+  // If no ABI decode, try UTF-8 text decode
+  const utf8Text = !resolved ? tryDecodeUtf8(inputData) : null;
 
   return (
     <div className="analyser-tab-content">
@@ -55,6 +62,16 @@ const InputDataTab: React.FC<{
                 ))}
               </div>
             )}
+          </div>
+        </div>
+      )}
+      {utf8Text && (
+        <div className="analyser-input-decoded">
+          <div className="analyser-summary">
+            <span>{t("analyser.utf8Text")}</span>
+          </div>
+          <div className="tx-input-utf8">
+            <pre>{utf8Text}</pre>
           </div>
         </div>
       )}

--- a/src/locales/en/transaction.json
+++ b/src/locales/en/transaction.json
@@ -169,6 +169,7 @@
     "events": "Events",
     "inputDataTab": "Input Data",
     "rawInputData": "Raw Input Data",
+    "utf8Text": "UTF-8 Decoded Text",
     "expandAll": "Expand All",
     "collapseAll": "Collapse All",
     "expand": "Expand",

--- a/src/locales/es/transaction.json
+++ b/src/locales/es/transaction.json
@@ -169,6 +169,7 @@
     "events": "Eventos",
     "inputDataTab": "Datos de Entrada",
     "rawInputData": "Datos de Entrada sin Procesar",
+    "utf8Text": "Texto Decodificado UTF-8",
     "expandAll": "Expandir Todo",
     "collapseAll": "Colapsar Todo",
     "expand": "Expandir",

--- a/src/locales/ja/transaction.json
+++ b/src/locales/ja/transaction.json
@@ -169,6 +169,7 @@
     "events": "イベント",
     "inputDataTab": "入力データ",
     "rawInputData": "生の入力データ",
+    "utf8Text": "UTF-8 デコードテキスト",
     "expandAll": "すべて展開",
     "collapseAll": "すべて折りたたむ",
     "expand": "展開",

--- a/src/locales/pt-BR/transaction.json
+++ b/src/locales/pt-BR/transaction.json
@@ -169,6 +169,7 @@
     "events": "Eventos",
     "inputDataTab": "Dados de Entrada",
     "rawInputData": "Dados de Entrada Brutos",
+    "utf8Text": "Texto Decodificado UTF-8",
     "expandAll": "Expandir Tudo",
     "collapseAll": "Recolher Tudo",
     "expand": "Expandir",

--- a/src/locales/zh/transaction.json
+++ b/src/locales/zh/transaction.json
@@ -169,6 +169,7 @@
     "events": "事件",
     "inputDataTab": "输入数据",
     "rawInputData": "原始输入数据",
+    "utf8Text": "UTF-8 解码文本",
     "expandAll": "全部展开",
     "collapseAll": "全部折叠",
     "expand": "展开",

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -387,6 +387,24 @@
 	color: var(--text-primary);
 }
 
+.tx-input-utf8 {
+	background: var(--overlay-light-5);
+	border: 1px solid var(--overlay-light-10);
+	border-radius: 6px;
+	padding: 12px;
+	max-height: 400px;
+	overflow: auto;
+}
+
+.tx-input-utf8 pre {
+	font-family: "JetBrains Mono", "Fira Code", monospace;
+	font-size: 0.8rem;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+	color: var(--text-primary);
+	margin: 0;
+}
+
 .tx-empty {
 	color: var(--text-secondary);
 	font-style: italic;

--- a/src/utils/inputDecoder.ts
+++ b/src/utils/inputDecoder.ts
@@ -227,3 +227,41 @@ export function decodeEventWithAbi(
     };
   }
 }
+
+/**
+ * Try to decode hex input data as UTF-8 text.
+ * Returns the decoded string if ≥80% of characters are printable, null otherwise.
+ */
+export function tryDecodeUtf8(hex: string): string | null {
+  if (!hex || hex === "0x" || hex.length < 4) return null;
+
+  const cleaned = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (cleaned.length === 0 || cleaned.length % 2 !== 0) return null;
+
+  const bytes = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < cleaned.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(cleaned.substring(i, i + 2), 16);
+  }
+
+  const decoded = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+
+  // Check if mostly printable (letters, digits, punctuation, whitespace)
+  let printable = 0;
+  for (let i = 0; i < decoded.length; i++) {
+    const code = decoded.charCodeAt(i);
+    if (
+      (code >= 0x20 && code <= 0x7e) || // ASCII printable
+      code === 0x09 || // tab
+      code === 0x0a || // newline
+      code === 0x0d || // carriage return
+      code >= 0x80 // multibyte (accented chars, CJK, emoji, etc.)
+    ) {
+      printable++;
+    }
+  }
+
+  const ratio = printable / decoded.length;
+  if (ratio < 0.8) return null;
+
+  return decoded;
+}


### PR DESCRIPTION
## Description
When transaction input data is not an ABI-encoded function call, attempt to decode it as UTF-8 text. If the result is mostly printable characters (≥80%), display it in a readable pre-formatted block above the raw hex.

## Related Issue
Closes #311

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement

## Changes Made
- Added `tryDecodeUtf8()` utility in `src/utils/inputDecoder.ts` — decodes hex to bytes, runs through TextDecoder, checks printable ratio
- Updated `InputDataTab` to show "UTF-8 Decoded Text" section when ABI decode fails but UTF-8 decode succeeds
- Added `.tx-input-utf8` CSS styles (scrollable pre block, max 400px height)
- Added `analyser.utf8Text` i18n key to all 5 locales

## Test Transaction
- [EF Mandate tx](https://etherscan.io/tx/0x5dd574df963a1df1f064791e0f6ff41ec972cdbba12293b7e1ece582052ba855) — self-transfer with the full Ethereum Foundation Mandate encoded as UTF-8 in input data

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] My code follows the project's architecture patterns