### PR TITLE
fix(ci): replace Storacha with Kubo for IPFS hash generation

### DIFF
--- a/.github/workflows/hash-deploy-build.yml
+++ b/.github/workflows/hash-deploy-build.yml
@@ -26,17 +26,29 @@ jobs:
       - name: Build Production
         run: ./scripts/build-production.sh
 
-      - name: Upload to Storacha
-        id: upload
-        uses: storacha/add-to-web3@v4
-        with:
-          path_to_add: './dist'
-          secret_key: ${{ secrets.STORACHA_PRINCIPAL }}
-          proof: ${{ secrets.STORACHA_PROOF }}
+      - name: Install Kubo (IPFS CLI)
+        run: |
+          wget -q https://dist.ipfs.tech/kubo/v0.34.1/kubo_v0.34.1_linux-amd64.tar.gz
+          tar -xzf kubo_v0.34.1_linux-amd64.tar.gz
+          sudo cp kubo/ipfs /usr/local/bin/
+          ipfs init --profile=badgerds
+          ipfs version
+
+      - name: Generate IPFS Hash
+        id: ipfs
+        run: |
+          HASH=$(ipfs add -r -Q --chunker=size-262144 --raw-leaves=false ./dist)
+          HASH_V1=$(ipfs cid format -v 1 -b base32 $HASH)
+
+          echo "hash_v0=$HASH" >> $GITHUB_OUTPUT
+          echo "hash_v1=$HASH_V1" >> $GITHUB_OUTPUT
+
+          echo "IPFS Hash (v0): $HASH"
+          echo "IPFS Hash (v1): $HASH_V1"
 
       - name: Update IPFS Hash in Repo
         run: |
-          HASH="${{ steps.upload.outputs.cid }}"
+          HASH="${{ steps.ipfs.outputs.hash_v0 }}"
 
           # Create shields.io endpoint format JSON
           mkdir -p /tmp/ipfs-meta

--- a/scripts/build-production.sh
+++ b/scripts/build-production.sh
@@ -27,19 +27,26 @@ NODE_ENV=production REACT_APP_COMMIT_HASH=$COMMIT_HASH npm run build
 echo "Production build completed!"
 echo "Build output is in ./dist/"
 
-# Get IPFS hash (ensure consistent chunking)
-ipfs add -r --chunker=size-262144 --raw-leaves=false ./dist
-HASH=$(ipfs add -r -Q --chunker=size-262144 --raw-leaves=false ./dist)
-HASH_V1=$(ipfs cid format -v 1 -b base32 $HASH)
+# Generate IPFS hash if ipfs CLI (Kubo) is available
+if command -v ipfs &> /dev/null; then
+  echo ""
+  echo "Generating IPFS hash..."
+  HASH=$(ipfs add -r -Q --chunker=size-262144 --raw-leaves=false ./dist)
+  HASH_V1=$(ipfs cid format -v 1 -b base32 $HASH)
 
-echo "IPFS Hash (v0): $HASH"
-echo "IPFS Hash (v1): $HASH_V1"
-echo ""
-echo "IPFS URLs:"
-echo "  - https://ipfs.io/ipfs/$HASH"
-echo "  - https://cloudflare-ipfs.com/ipfs/$HASH"
-echo "  - https://gateway.ipfs.io/ipfs/$HASH"
-echo ""
-echo "IPFS v1 URLs:"
-echo "  - https://$HASH_V1.ipfs.dweb.link"
-echo "  - https://$HASH_V1.ipfs.cf-ipfs.com"
+  echo "IPFS Hash (v0): $HASH"
+  echo "IPFS Hash (v1): $HASH_V1"
+  echo ""
+  echo "IPFS URLs:"
+  echo "  - https://ipfs.io/ipfs/$HASH"
+  echo "  - https://cloudflare-ipfs.com/ipfs/$HASH"
+  echo "  - https://gateway.ipfs.io/ipfs/$HASH"
+  echo ""
+  echo "IPFS v1 URLs:"
+  echo "  - https://$HASH_V1.ipfs.dweb.link"
+  echo "  - https://$HASH_V1.ipfs.cf-ipfs.com"
+else
+  echo ""
+  echo "IPFS CLI (Kubo) not found. Skipping hash generation."
+  echo "Install Kubo to generate IPFS hashes: https://docs.ipfs.tech/install/"
+fi


### PR DESCRIPTION
## Description

Replace Storacha's `add-to-web3` action with Kubo (IPFS CLI) in the CI workflow to ensure consistent IPFS hash generation between local and CI environments.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **CI Workflow** (`.github/workflows/hash-deploy-build.yml`):
  - Removed Storacha `add-to-web3@v4` action and associated secrets
  - Added Kubo v0.34.1 installation step
  - Added IPFS hash generation using `ipfs add` with consistent chunking params (`--chunker=size-262144 --raw-leaves=false`)
  - Meta branch now stores the CIDv0 hash from Kubo

- **Build Script** (`scripts/build-production.sh`):
  - Wrapped IPFS hash generation behind a `command -v ipfs` check so the script doesn't fail when Kubo isn't installed
  - Removed redundant verbose `ipfs add` call (was running twice)

## Why

Storacha uses different UnixFS encoding parameters (1 MiB raw-leaf chunks, width 1024) than our local Kubo setup (256 KiB UnixFS-wrapped chunks, width 174), producing mismatched CIDs between local and CI builds. Using Kubo in both environments ensures identical hashes.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

The Storacha secrets (`STORACHA_PRINCIPAL`, `STORACHA_PROOF`) can be removed from the repository settings after merging.