### PR TITLE
fix: invalidate metadata cache on version bump

### DIFF
--- a/src/services/MetadataService.ts
+++ b/src/services/MetadataService.ts
@@ -7,7 +7,8 @@ import networksData from "../config/networks.json";
 import { logger } from "../utils/logger";
 import { extractChainIdFromNetworkId } from "../utils/networkResolver";
 
-const METADATA_BASE_URL = "https://cdn.jsdelivr.net/npm/@openscan/metadata@1.1.2-alpha.0/dist";
+export const METADATA_VERSION = "1.1.2-alpha.0";
+const METADATA_BASE_URL = `https://cdn.jsdelivr.net/npm/@openscan/metadata@${METADATA_VERSION}/dist`;
 
 export interface NetworkLink {
   name: string;

--- a/src/utils/rpcStorage.ts
+++ b/src/utils/rpcStorage.ts
@@ -1,4 +1,4 @@
-import type { MetadataRpcEndpoint } from "../services/MetadataService";
+import { type MetadataRpcEndpoint, METADATA_VERSION } from "../services/MetadataService";
 import type { RpcUrlsContextType } from "../types";
 import { logger } from "./logger";
 
@@ -16,6 +16,7 @@ const BUILTIN_RPC_DEFAULTS: RpcUrlsContextType = {
 
 interface MetadataRpcCache {
   timestamp: number;
+  version?: string;
   rpcs: Record<string, MetadataRpcEndpoint[]>;
 }
 
@@ -40,7 +41,7 @@ export function loadMetadataRpcsFromStorage(): MetadataRpcCache | null {
  */
 export function saveMetadataRpcsToStorage(rpcs: Record<string, MetadataRpcEndpoint[]>): void {
   try {
-    const cache: MetadataRpcCache = { timestamp: Date.now(), rpcs };
+    const cache: MetadataRpcCache = { timestamp: Date.now(), version: METADATA_VERSION, rpcs };
     localStorage.setItem(METADATA_RPC_STORAGE_KEY, JSON.stringify(cache));
   } catch (err) {
     logger.warn("Failed to save metadata RPCs to storage", err);
@@ -53,6 +54,7 @@ export function saveMetadataRpcsToStorage(rpcs: Record<string, MetadataRpcEndpoi
 export function isMetadataRpcCacheFresh(): boolean {
   const cache = loadMetadataRpcsFromStorage();
   if (!cache) return false;
+  if (cache.version !== METADATA_VERSION) return false;
   return Date.now() - cache.timestamp < METADATA_RPC_TTL;
 }
 


### PR DESCRIPTION
## Description
Bumps `@openscan/metadata` to `1.1.2-alpha.0` (adds Avalanche C-Chain RPCs) and fixes metadata cache invalidation so users get new RPC endpoints immediately when the metadata version is bumped.

## Related Issue
Fixes Avalanche C-Chain "No RPC endpoint configured" error for users with stale cached metadata.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made
- Bump `@openscan/metadata` from `1.1.1-alpha.0` to `1.1.2-alpha.0`
- Extract `METADATA_VERSION` constant from the URL in `MetadataService.ts`
- Store the metadata version in the RPC cache (`rpcStorage.ts`)
- On startup, if the cached version doesn't match `METADATA_VERSION`, treat the cache as stale and refetch immediately — no need to wait for the 24h TTL

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [x] My code follows the project's architecture patterns