### PR TITLE
Fix npm publish github action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -28,7 +28,7 @@ jobs:
         run: bash ./scripts/build-development.sh
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Description

Fix npm publish CI workflow failing with ENEEDAUTH by bumping GitHub Actions to v5, matching the working workflows in other openscan repos.


## Related Issue

Fixes failing [Publish to npm](https://github.com/openscan-explorer/explorer/actions/runs/23561265797/job/68601450872) workflow run.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Bumped actions/checkout from v4 to v5
- Bumped actions/setup-node from v4 to v5

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run`
- [ ] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

The v5 versions properly support OIDC (Trusted Publishing) for npm authentication. The v4 versions were not wiring the OIDC token correctly, causing ENEEDAUTH errors during npm publish. This aligns the explorer workflow with the working workflows in network-connectors, hardhat-plugin, and explorer-metadata.


The other openscan repos (network-connectors, hardhat-plugin, explorer-metadata) already use v5 for both actions and publish successfully with OIDC authentication.