### PR TITLE
refactor: migrate REACT_APP_ env vars to OPENSCAN_ prefix

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -65,6 +65,6 @@ Located in `src/types/index.ts`:
 - **Vite** (`vite.config.ts`) - Fast bundler with TypeScript, CSS, and asset loading
 - **GitHub Pages**: Set `GITHUB_PAGES=true` for `/explorer/` base path
 - **Environment Variables**: Injected via Vite's `define` option:
-  - `REACT_APP_COMMIT_HASH` - Git commit hash
-  - `REACT_APP_OPENSCAN_NETWORKS` - Comma-separated chain IDs to display
-  - `REACT_APP_ENVIRONMENT` - production/development
+  - `OPENSCAN_COMMIT_HASH` - Git commit hash
+  - `OPENSCAN_NETWORKS` - Comma-separated chain IDs to display
+  - `OPENSCAN_ENVIRONMENT` - production/development

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -87,7 +87,7 @@ Networks are defined in `src/config/networks.ts`. To control which networks are 
 
 ```bash
 # Show only specific networks (comma-separated chain IDs)
-REACT_APP_OPENSCAN_NETWORKS="1,31337" npm start
+OPENSCAN_NETWORKS="1,31337" npm start
 
 # Show all networks (default)
 npm start

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ chmod +x .git/hooks/pre-commit
 
 ### Environment Variables
 
-#### `REACT_APP_OPENSCAN_NETWORKS`
+#### `OPENSCAN_NETWORKS`
 
 Controls which networks are displayed in the application. This is useful for limiting the explorer to specific chains.
 
@@ -205,19 +205,19 @@ Controls which networks are displayed in the application. This is useful for lim
 
 **Default:** If not set, all supported networks are enabled.
 
-**Note:** The Localhost network (31337) is only visible in development mode. To enable it in production/staging, explicitly include it in `REACT_APP_OPENSCAN_NETWORKS`.
+**Note:** The Localhost network (31337) is only visible in development mode. To enable it in production/staging, explicitly include it in `OPENSCAN_NETWORKS`.
 
 **Examples:**
 
 ```bash
 # Show only Ethereum Mainnet and Localhost
-REACT_APP_OPENSCAN_NETWORKS="1,31337" npm start
+OPENSCAN_NETWORKS="1,31337" npm start
 
 # Show only Layer 2 networks
-REACT_APP_OPENSCAN_NETWORKS="42161,10,8453" npm start
+OPENSCAN_NETWORKS="42161,10,8453" npm start
 
 # Show only testnets
-REACT_APP_OPENSCAN_NETWORKS="11155111,97" npm start
+OPENSCAN_NETWORKS="11155111,97" npm start
 ```
 
 The networks will be displayed in the order specified in the environment variable.

--- a/scripts/build-development.sh
+++ b/scripts/build-development.sh
@@ -15,7 +15,7 @@ rm -r dist || true
 
 # Build the app with only Hardhat network (31337) enabled
 echo "Building React app on commit $COMMIT_HASH"
-NODE_ENV=development REACT_APP_ENVIRONMENT=development REACT_APP_COMMIT_HASH=$COMMIT_HASH REACT_APP_OPENSCAN_NETWORKS=31337 npm run build
+NODE_ENV=development OPENSCAN_COMMIT_HASH=$COMMIT_HASH OPENSCAN_NETWORKS=31337 npm run build
 
 # Generate dist/package.json for npm publishing
 VERSION=$(node -p "require('./package.json').version")

--- a/scripts/build-production.sh
+++ b/scripts/build-production.sh
@@ -12,7 +12,7 @@ bun install --frozen-lockfile
 
 # Create .env file for production
 echo "Creating production environment file..."
-echo "REACT_APP_ENVIRONMENT=production" > .env
+echo "OPENSCAN_ENVIRONMENT=production" > .env
 
 # Get current commit hash
 COMMIT_HASH=$(git rev-parse HEAD)
@@ -22,7 +22,7 @@ rm -rf dist || true
 
 # Build the app using Vite
 echo "Building React app on commit $COMMIT_HASH"
-NODE_ENV=production REACT_APP_COMMIT_HASH=$COMMIT_HASH npm run build
+NODE_ENV=production OPENSCAN_COMMIT_HASH=$COMMIT_HASH npm run build
 
 echo "Production build completed!"
 echo "Build output is in ./dist/"

--- a/scripts/build-staging.sh
+++ b/scripts/build-staging.sh
@@ -15,6 +15,6 @@ COMMIT_HASH=$(git rev-parse HEAD)
 
 # Build the app using Vite
 echo "Building React app on commit $COMMIT_HASH"
-NODE_ENV=staging REACT_APP_COMMIT_HASH=$COMMIT_HASH npm run build
+NODE_ENV=staging OPENSCAN_COMMIT_HASH=$COMMIT_HASH npm run build
 echo "Staging build completed!"
 echo "Build output is in ./dist/"

--- a/scripts/run-test-env.sh
+++ b/scripts/run-test-env.sh
@@ -86,7 +86,7 @@ echo "🔍 Starting OpenScan (Ethereum Mainnet + hardhat only)..."
 cd "$OPENSCAN_DIR"
 
 # Start OpenScan - it will read .env.local on start
-REACT_APP_OPENSCAN_NETWORKS="31337" npm start &
+OPENSCAN_NETWORKS="31337" npm start &
 OPENSCAN_PID=$!
 
 # Wait for OpenScan to start

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -16,17 +16,17 @@ const Footer: React.FC<FooterProps> = ({ className = "" }) => {
   const { isSuperUser } = useSettings();
 
   // Get commit hash from environment variable, fallback to 'development'
-  const commitHash = process.env.REACT_APP_COMMIT_HASH || "development";
+  const commitHash = import.meta.env.OPENSCAN_COMMIT_HASH || "development";
 
   // Format commit hash - show first 7 characters if it's a full hash
   const formattedCommitHash = commitHash.length > 7 ? commitHash.substring(0, 7) : commitHash;
 
   // Get version from environment variable or fallback
-  const appVersion = process.env.REACT_APP_VERSION || "0.1.0";
+  const appVersion = import.meta.env.OPENSCAN_VERSION || "0.1.0";
 
   // Get the GitHub repository URL from package.json or environment
   const repoUrl =
-    process.env.REACT_APP_GITHUB_REPO || "https://github.com/openscan-explorer/explorer";
+    import.meta.env.OPENSCAN_GITHUB_REPO || "https://github.com/openscan-explorer/explorer";
 
   // Determine footer version class based on environment
   const getVersionClass = () => {

--- a/src/components/pages/home/index.tsx
+++ b/src/components/pages/home/index.tsx
@@ -54,7 +54,7 @@ export default function Home() {
   const [showTestnets, setShowTestnets] = useState(false);
 
   const { featuredNetworks, productionNetworks, testnetNetworks } = useMemo(() => {
-    const isDevelopment = import.meta.env.VITE_ENVIRONMENT === "development";
+    const isDevelopment = import.meta.env.OPENSCAN_ENVIRONMENT === "development";
     const localhostChainId = 31337;
 
     // In development, treat localhost as a production network (show with other networks)

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -92,18 +92,18 @@ export function getAllNetworks(): NetworkConfig[] {
 
 /**
  * Get the list of enabled networks based on environment variable
- * REACT_APP_OPENSCAN_NETWORKS can be a comma-separated list of chain IDs, slugs, or network IDs
+ * OPENSCAN_NETWORKS can be a comma-separated list of chain IDs, slugs, or network IDs
  * If not set, all networks are enabled
  */
 export function getEnabledNetworks(): NetworkConfig[] {
   const allNetworks = getAllNetworks();
-  const envNetworks = process.env.REACT_APP_OPENSCAN_NETWORKS;
+  const envNetworks: string | undefined = import.meta.env.OPENSCAN_NETWORKS;
   const localhostChainId = 31337;
 
-  // VITE_ENVIRONMENT is injected via vite.config.ts define block based on NODE_ENV
-  const isDevelopment = import.meta.env.VITE_ENVIRONMENT === "development";
+  // OPENSCAN_ENVIRONMENT is injected via vite.config.ts define block based on NODE_ENV
+  const isDevelopment = import.meta.env.OPENSCAN_ENVIRONMENT === "development";
 
-  // Check if localhost is explicitly enabled in REACT_APP_OPENSCAN_NETWORKS
+  // Check if localhost is explicitly enabled in OPENSCAN_NETWORKS
   const isLocalhostExplicitlyEnabled = envNetworks
     ?.split(",")
     .map((id) => id.trim())

--- a/src/config/subdomains.ts
+++ b/src/config/subdomains.ts
@@ -14,7 +14,7 @@ export interface SubdomainConfig {
 const WEENUS_SEPOLIA_ADDRESS = "0x7E0987E5b3a30e3f2828572Bb659A548460a3003";
 
 // Check if we're in development mode
-const isDevelopment = import.meta.env.VITE_ENVIRONMENT === "development";
+const isDevelopment = import.meta.env.OPENSCAN_ENVIRONMENT === "development";
 
 export const subdomainConfig: SubdomainConfig[] = [
   // Network subdomains

--- a/src/config/workerConfig.ts
+++ b/src/config/workerConfig.ts
@@ -1,3 +1,3 @@
 /** Base URL for the OpenScan Cloudflare Worker proxy */
 export const OPENSCAN_WORKER_URL =
-  process.env.REACT_APP_OPENSCAN_WORKER_URL || "https://openscan-worker-proxy.openscan.workers.dev";
+  import.meta.env.OPENSCAN_WORKER_URL || "https://openscan-worker-proxy.openscan.workers.dev";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const ENVIRONMENT = import.meta.env.VITE_ENVIRONMENT || "development";
+export const ENVIRONMENT = import.meta.env.OPENSCAN_ENVIRONMENT || "development";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,24 +44,15 @@ export default defineConfig({
       },
     },
   },
+  envPrefix: "OPENSCAN_",
   define: {
-    "process.env.REACT_APP_COMMIT_HASH": JSON.stringify(
-      process.env.REACT_APP_COMMIT_HASH || commitHash
+    "import.meta.env.OPENSCAN_COMMIT_HASH": JSON.stringify(
+      process.env.OPENSCAN_COMMIT_HASH || commitHash
     ),
-    "process.env.REACT_APP_GITHUB_REPO": JSON.stringify(
-      process.env.REACT_APP_GITHUB_REPO ||
-        "https://github.com/openscan-explorer/explorer"
+    "import.meta.env.OPENSCAN_VERSION": JSON.stringify(
+      process.env.OPENSCAN_VERSION || appVersion
     ),
-    "process.env.REACT_APP_VERSION": JSON.stringify(
-      process.env.REACT_APP_VERSION || appVersion
-    ),
-    "process.env.REACT_APP_OPENSCAN_NETWORKS": JSON.stringify(
-      process.env.REACT_APP_OPENSCAN_NETWORKS || ""
-    ),
-    "process.env.REACT_APP_OPENSCAN_WORKER_URL": JSON.stringify(
-      process.env.REACT_APP_OPENSCAN_WORKER_URL || "https://openscan-worker-proxy.openscan.workers.dev"
-    ),
-    "import.meta.env.VITE_ENVIRONMENT": JSON.stringify(
+    "import.meta.env.OPENSCAN_ENVIRONMENT": JSON.stringify(
       process.env.NODE_ENV || "development"
     ),
   },


### PR DESCRIPTION
## Description

Migrates all `REACT_APP_*` environment variables to `OPENSCAN_*` prefix convention and replaces `process.env` access with `import.meta.env`. Adds `envPrefix: "OPENSCAN_"` to Vite config so env vars are auto-exposed without manual `define` entries.

## Related Issue

Closes #347

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **`vite.config.ts`**: Added `envPrefix: "OPENSCAN_"`. Reduced `define` map from 6 entries to 3 (only computed defaults: `OPENSCAN_COMMIT_HASH`, `OPENSCAN_VERSION`, `OPENSCAN_ENVIRONMENT`). Removed manual entries for `GITHUB_REPO`, `OPENSCAN_NETWORKS`, and `OPENSCAN_WORKER_URL` since Vite auto-exposes them.
- **Source files** (`Footer.tsx`, `networks.ts`, `workerConfig.ts`, `constants.ts`, `subdomains.ts`, `home/index.tsx`): Replaced `process.env.REACT_APP_*` / `import.meta.env.VITE_*` with `import.meta.env.OPENSCAN_*`.
- **Build scripts** (`build-production.sh`, `build-staging.sh`, `build-development.sh`, `run-test-env.sh`): Updated env var names from `REACT_APP_*` to `OPENSCAN_*`.
- **Documentation** (`README.md`, `.claude/rules/architecture.md`, `.claude/rules/commands.md`): Updated all env var references.

## Checklist
- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [ ] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

No CI/CD workflow changes needed — GitHub Actions workflows don't reference these env vars directly.