### PR TITLE
feat(networks): add 5 EVM testnets from metadata v1.2.1-alpha.0

### DIFF
--- a/src/config/networks.json
+++ b/src/config/networks.json
@@ -286,6 +286,126 @@
       ]
     },
     {
+      "type": "evm",
+      "networkId": "eip155:421614",
+      "slug": "arb-sepolia",
+      "name": "Arbitrum Sepolia",
+      "shortName": "Arb Sepolia",
+      "description": "Arbitrum testnet for developers",
+      "currency": "ETH",
+      "color": "#28A0F0",
+      "isTestnet": true,
+      "logo": "assets/networks/421614.svg",
+      "links": [
+        {
+          "name": "Bridge",
+          "url": "https://bridge.arbitrum.io",
+          "description": "Bridge from Sepolia"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.arbitrum.io",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "type": "evm",
+      "networkId": "eip155:11155420",
+      "slug": "op-sepolia",
+      "name": "Optimism Sepolia",
+      "shortName": "OP Sepolia",
+      "description": "Optimism testnet for developers",
+      "currency": "ETH",
+      "color": "#FF0420",
+      "isTestnet": true,
+      "logo": "assets/networks/11155420.svg",
+      "links": [
+        {
+          "name": "Bridge",
+          "url": "https://app.optimism.io/bridge",
+          "description": "Bridge from Sepolia"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.optimism.io",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "type": "evm",
+      "networkId": "eip155:84532",
+      "slug": "base-sepolia",
+      "name": "Base Sepolia",
+      "shortName": "Base Sepolia",
+      "description": "Base testnet for developers",
+      "currency": "ETH",
+      "color": "#0052FF",
+      "isTestnet": true,
+      "logo": "assets/networks/84532.svg",
+      "links": [
+        {
+          "name": "Faucet",
+          "url": "https://www.coinbase.com/faucets/base-ethereum-sepolia-faucet",
+          "description": "Get testnet ETH"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.base.org",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "type": "evm",
+      "networkId": "eip155:80002",
+      "slug": "polygon-amoy",
+      "name": "Polygon Amoy",
+      "shortName": "Amoy",
+      "description": "Polygon testnet for developers",
+      "currency": "POL",
+      "color": "#8247E5",
+      "isTestnet": true,
+      "logo": "assets/networks/80002.svg",
+      "links": [
+        {
+          "name": "Faucet",
+          "url": "https://faucet.polygon.technology",
+          "description": "Get testnet POL"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.polygon.technology",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
+      "type": "evm",
+      "networkId": "eip155:43113",
+      "slug": "avax-fuji",
+      "name": "Avalanche Fuji",
+      "shortName": "Fuji",
+      "description": "Avalanche testnet for developers",
+      "currency": "AVAX",
+      "color": "#E84142",
+      "isTestnet": true,
+      "logo": "assets/networks/43113.svg",
+      "links": [
+        {
+          "name": "Faucet",
+          "url": "https://faucet.avax.network",
+          "description": "Get testnet AVAX"
+        },
+        {
+          "name": "Docs",
+          "url": "https://docs.avax.network",
+          "description": "Developer documentation"
+        }
+      ]
+    },
+    {
       "type": "solana",
       "networkId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
       "slug": "sol",

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -23,9 +23,16 @@ type EVMClientConfig = {
   type: "fallback" | "parallel" | "race";
 };
 
+type EVMTestnetClient =
+  | ArbitrumClient
+  | OptimismClient
+  | BaseClient
+  | PolygonClient
+  | EthereumClient;
+
 // EVM testnets not yet registered in @openscan/network-connectors ClientFactory.
 // Mapped to their L1 family's client since they share the same JSON-RPC surface.
-const EVM_TESTNET_CLIENTS: Record<number, (config: EVMClientConfig) => unknown> = {
+const EVM_TESTNET_CLIENTS: Record<number, (config: EVMClientConfig) => EVMTestnetClient> = {
   421614: (config) => new ArbitrumClient(config),
   11155420: (config) => new OptimismClient(config),
   84532: (config) => new BaseClient(config),

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -1,8 +1,13 @@
 import {
   type SupportedChainId,
   type SupportedSolanaChainId,
-  ClientFactory,
+  ArbitrumClient,
+  BaseClient,
   BitcoinClient,
+  ClientFactory,
+  EthereumClient,
+  OptimismClient,
+  PolygonClient,
 } from "@openscan/network-connectors";
 
 import { AdapterFactory } from "./adapters/adaptersFactory";
@@ -12,6 +17,21 @@ import type { SolanaAdapter } from "./adapters/SolanaAdapter/SolanaAdapter";
 import type { NetworkConfig, RpcUrlsContextType } from "../types";
 import { getRPCUrls } from "../config/rpcConfig";
 import { getNetworkRpcKey, getChainIdFromNetwork } from "../utils/networkResolver";
+
+type EVMClientConfig = {
+  rpcUrls: string[];
+  type: "fallback" | "parallel" | "race";
+};
+
+// EVM testnets not yet registered in @openscan/network-connectors ClientFactory.
+// Mapped to their L1 family's client since they share the same JSON-RPC surface.
+const EVM_TESTNET_CLIENTS: Record<number, (config: EVMClientConfig) => unknown> = {
+  421614: (config) => new ArbitrumClient(config),
+  11155420: (config) => new OptimismClient(config),
+  84532: (config) => new BaseClient(config),
+  80002: (config) => new PolygonClient(config),
+  43113: (config) => new EthereumClient(config),
+};
 
 /**
  * DataService supports EVM, Bitcoin, and Solana networks
@@ -58,10 +78,10 @@ export class DataService {
     } else {
       // Create EVM client and adapter
       const chainId = getChainIdFromNetwork(network) as SupportedChainId;
-      const networkClient = ClientFactory.createTypedClient<typeof chainId>(chainId, {
-        rpcUrls,
-        type: strategy,
-      });
+      const clientConfig = { rpcUrls, type: strategy };
+      const networkClient =
+        EVM_TESTNET_CLIENTS[chainId as number]?.(clientConfig) ??
+        ClientFactory.createTypedClient<typeof chainId>(chainId, clientConfig);
       this.networkAdapter = AdapterFactory.createAdapter(chainId, networkClient);
     }
   }

--- a/src/services/MetadataService.ts
+++ b/src/services/MetadataService.ts
@@ -7,7 +7,7 @@ import networksData from "../config/networks.json";
 import { logger } from "../utils/logger";
 import { extractChainIdFromNetworkId } from "../utils/networkResolver";
 
-export const METADATA_VERSION = "1.2.0-alpha.0";
+export const METADATA_VERSION = "1.2.1-alpha.0";
 const METADATA_BASE_URL = `https://cdn.jsdelivr.net/npm/@openscan/metadata@${METADATA_VERSION}/dist`;
 
 export interface NetworkLink {

--- a/src/services/adapters/ArbitrumAdapter/ArbitrumAdapter.ts
+++ b/src/services/adapters/ArbitrumAdapter/ArbitrumAdapter.ts
@@ -23,7 +23,7 @@ import type { ArbitrumClient, EthereumClient } from "@openscan/network-connector
 export class ArbitrumAdapter extends NetworkAdapter {
   private client: ArbitrumClient;
 
-  constructor(networkId: 42161, client: ArbitrumClient) {
+  constructor(networkId: 42161 | 421614, client: ArbitrumClient) {
     super(networkId);
     this.client = client;
     this.initTxSearch(client as unknown as EthereumClient);

--- a/src/services/adapters/BaseAdapter/BaseAdapter.ts
+++ b/src/services/adapters/BaseAdapter/BaseAdapter.ts
@@ -22,7 +22,7 @@ import type { BaseClient, EthereumClient } from "@openscan/network-connectors";
 export class BaseAdapter extends NetworkAdapter {
   private client: BaseClient;
 
-  constructor(networkId: 8453, client: BaseClient) {
+  constructor(networkId: 8453 | 84532, client: BaseClient) {
     super(networkId);
     this.client = client;
     this.initTxSearch(client as unknown as EthereumClient);

--- a/src/services/adapters/OptimismAdapter/OptimismAdapter.ts
+++ b/src/services/adapters/OptimismAdapter/OptimismAdapter.ts
@@ -22,7 +22,7 @@ import type { OptimismClient, EthereumClient } from "@openscan/network-connector
 export class OptimismAdapter extends NetworkAdapter {
   private client: OptimismClient;
 
-  constructor(networkId: 10, client: OptimismClient) {
+  constructor(networkId: 10 | 11155420, client: OptimismClient) {
     super(networkId);
     this.client = client;
     this.initTxSearch(client as unknown as EthereumClient);

--- a/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
+++ b/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
@@ -12,7 +12,7 @@ import {
 
 import { normalizeBlockNumber } from "../shared/normalizeBlockNumber";
 import { mergeMetadata } from "../shared/mergeMetadata";
-import type { PolygonClient, SupportedChainId, EthereumClient } from "@openscan/network-connectors";
+import type { PolygonClient, EthereumClient } from "@openscan/network-connectors";
 
 /**
  * Polygon blockchain service
@@ -21,7 +21,7 @@ import type { PolygonClient, SupportedChainId, EthereumClient } from "@openscan/
 export class PolygonAdapter extends NetworkAdapter {
   private client: PolygonClient;
 
-  constructor(networkId: SupportedChainId | 80002, client: PolygonClient) {
+  constructor(networkId: 137 | 80002, client: PolygonClient) {
     super(networkId);
     this.client = client;
     this.initTxSearch(client as unknown as EthereumClient);

--- a/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
+++ b/src/services/adapters/PolygonAdapter/PolygonAdapter.ts
@@ -21,7 +21,7 @@ import type { PolygonClient, SupportedChainId, EthereumClient } from "@openscan/
 export class PolygonAdapter extends NetworkAdapter {
   private client: PolygonClient;
 
-  constructor(networkId: SupportedChainId, client: PolygonClient) {
+  constructor(networkId: SupportedChainId | 80002, client: PolygonClient) {
     super(networkId);
     this.client = client;
     this.initTxSearch(client as unknown as EthereumClient);

--- a/src/services/adapters/adaptersFactory.ts
+++ b/src/services/adapters/adaptersFactory.ts
@@ -39,8 +39,7 @@ export class AdapterFactory {
       | ArbitrumClient
       | AvalancheClient
       | AztecClient
-      | HardhatClient
-      | unknown,
+      | HardhatClient,
   ): NetworkAdapter {
     switch (networkId) {
       case 1:

--- a/src/services/adapters/adaptersFactory.ts
+++ b/src/services/adapters/adaptersFactory.ts
@@ -29,7 +29,7 @@ export class AdapterFactory {
    * Create an EVM network adapter
    */
   static createAdapter(
-    networkId: SupportedChainId,
+    networkId: SupportedChainId | number,
     client:
       | EthereumClient
       | OptimismClient
@@ -39,25 +39,31 @@ export class AdapterFactory {
       | ArbitrumClient
       | AvalancheClient
       | AztecClient
-      | HardhatClient,
+      | HardhatClient
+      | unknown,
   ): NetworkAdapter {
     switch (networkId) {
       case 1:
       case 11155111:
       case 43114:
+      case 43113:
         return new EVMAdapter(networkId, client as unknown as EthereumClient);
       case 31337:
         return new HardhatAdapter(client as HardhatClient);
       case 10:
+      case 11155420:
         return new OptimismAdapter(networkId, client as OptimismClient);
       case 56:
       case 97:
         return new BNBAdapter(networkId, client as BNBClient);
       case 137:
+      case 80002:
         return new PolygonAdapter(networkId, client as PolygonClient);
       case 8453:
+      case 84532:
         return new BaseAdapter(networkId, client as BaseClient);
       case 42161:
+      case 421614:
         return new ArbitrumAdapter(networkId, client as ArbitrumClient);
       default:
         throw new Error(`Unknown adapter for networkId: ${networkId}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,10 +10,10 @@ export type NetworkType = "evm" | "bitcoin" | "solana";
 
 /**
  * All EVM chain IDs supported by the app.
- * Maps directly to the connector library's SupportedChainId.
- * When adding a new EVM network, add its chain ID to network-connectors first.
+ * Extends the connector library's SupportedChainId with testnet chain IDs
+ * that reuse their L1 family's client (not yet registered in network-connectors).
  */
-export type AppChainId = SupportedChainId;
+export type AppChainId = SupportedChainId | 43113 | 421614 | 11155420 | 84532 | 80002;
 
 // ==================== CORE DOMAIN TYPES ====================
 


### PR DESCRIPTION
## Description

Adds 5 EVM testnets introduced in [explorer-metadata PR #16](https://github.com/openscan-explorer/explorer-metadata/pull/16) (released as `@openscan/metadata@1.2.1-alpha.0`): **Arbitrum Sepolia** (421614), **Optimism Sepolia** (11155420), **Base Sepolia** (84532), **Polygon Amoy** (80002), and **Avalanche Fuji** (43113).

Each new chain ID is routed to its L1 family's adapter so block/tx/account pages render the right L2-specific fields (Arbitrum `l1BlockNumber`/`sendCount`/`sendRoot`, OP/Base `l1Fee`/`l1GasPrice`/`l1GasUsed`).

## Related Issue

N/A — follows [explorer-metadata#16](https://github.com/openscan-explorer/explorer-metadata/pull/16).

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [ ] Other

## Changes Made

- **Bump `METADATA_VERSION` to `1.2.1-alpha.0`** (`src/services/MetadataService.ts`) — fetches refreshed RPCs, new testnet RPC lists, and new logos from jsDelivr. Also acts as localStorage cache-bust.
- **Add 5 testnet entries to `src/config/networks.json`** with slugs `arb-sepolia`, `op-sepolia`, `base-sepolia`, `polygon-amoy`, `avax-fuji`, each marked `isTestnet: true` with logo, color, currency, and faucet/bridge/docs links.
- **Register testnets in `AdapterFactory`** (`src/services/adapters/adaptersFactory.ts`):
  - `421614` → `ArbitrumAdapter`
  - `11155420` → `OptimismAdapter`
  - `84532` → `BaseAdapter`
  - `80002` → `PolygonAdapter`
  - `43113` → `EVMAdapter` (same as Avalanche mainnet)
- **Work around missing `ClientFactory` support** (`src/services/DataService.ts`) — `@openscan/network-connectors` does not yet register these testnet chain IDs in its `CHAIN_REGISTRY`, which would cause `ClientFactory.createTypedClient` to throw at runtime. `DataService` now instantiates the L1 family's client directly for the 5 testnet chain IDs via an `EVM_TESTNET_CLIENTS` lookup (they share the same JSON-RPC surface).
- **Widen `AppChainId` and L2 adapter constructor types** to accept the new testnet chain IDs alongside their mainnet pair (`42161 | 421614`, `10 | 11155420`, `8453 | 84532`, `137 | 80002`).
- **Tighten `PolygonAdapter` constructor type** from `SupportedChainId` to `137 | 80002` to match sibling L2 adapters (refactor commit).

## Screenshots

N/A — CDN-sourced logos and existing EVM page layouts.

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run` (88/88 pass)
- [ ] I have tested my changes locally
- [x] I have updated documentation if needed (no doc surface changed)
- [x] My code follows the project's architecture patterns

## Additional Notes

- **No changes to `BUILTIN_RPC_DEFAULTS`** (`src/utils/rpcStorage.ts`): the new testnets fetch RPCs purely from the metadata CDN, matching the pattern used by Sepolia and BSC Testnet.
- **Follow-up for `@openscan/network-connectors`**: once the library registers these 5 chain IDs in its `CHAIN_REGISTRY`, the `EVM_TESTNET_CLIENTS` workaround in `DataService.ts` can be removed and the widened types collapsed back.
- **Verification steps for reviewers:**
  1. DevTools → Application → Local Storage: clear `OPENSCAN_METADATA_RPCS`, reload, confirm the new cache entry's `version` is `"1.2.1-alpha.0"`.
  2. Navigate to `/arb-sepolia`, `/op-sepolia`, `/base-sepolia`, `/polygon-amoy`, `/avax-fuji` and confirm each network dashboard loads with block number + gas price.
  3. On Arb Sepolia, open a recent block detail and verify `l1BlockNumber` renders; on OP/Base Sepolia open a transaction and verify L1 fee fields.
  4. Settings → RPCs tab lists the new endpoints with `tracking`/`isOpenSource` metadata from v1.2.1.