### PR TITLE
fix(worker): anchor CORS origin allowlist to prevent Netlify-tenant abuse

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -53,7 +53,7 @@ All platforms require the same secrets:
 | `DRPC_API_KEY` | dRPC API key for `/evm/drpc/*`, `/btc/drpc` |
 | `ANKR_API_KEY` | Ankr API key for `/evm/ankr/*`, `/btc/ankr` |
 | `ONFINALITY_BTC_API_KEY` | OnFinality API key for `/btc/onfinality/*` |
-| `ALLOWED_ORIGINS` | Comma-separated allowed CORS origins |
+| `ALLOWED_ORIGINS` | Comma-separated allowed CORS origins. Entries prefixed with `re:` are anchored regex patterns matched against the full origin (e.g. `re:^https://(pr-\d+\|deploy-preview-\d+)--openscan\.netlify\.app$`). Other entries are exact matches. |
 | `GROQ_MODEL` | AI model (default: `groq/compound`) |
 
 ## Deployment

--- a/worker/src/middleware/cors.ts
+++ b/worker/src/middleware/cors.ts
@@ -3,20 +3,34 @@ import type { Env } from "../types";
 
 /**
  * Check if an origin is allowed.
- * Entries starting with "*" are suffix patterns on the hostname — e.g.
- * "*--openscan.netlify.app" matches "https://pr-306--openscan.netlify.app".
+ * Entries prefixed with "re:" are anchored regex patterns matched against the
+ * full origin — e.g. "re:^https://(pr-\\d+|deploy-preview-\\d+)--openscan\\.netlify\\.app$".
  * All other entries are exact origin matches.
+ *
+ * Suffix globs like "*--openscan.netlify.app" are intentionally NOT supported:
+ * Netlify site names are globally unique but user-chosen, so any tenant can
+ * register a site name ending in "--openscan" and satisfy a bare suffix match.
+ * Always anchor preview patterns to the expected prefix form.
  */
+const regexCache = new Map<string, RegExp | null>();
+
+function compilePattern(entry: string): RegExp | null {
+  if (regexCache.has(entry)) return regexCache.get(entry) ?? null;
+  let compiled: RegExp | null = null;
+  try {
+    compiled = new RegExp(entry.slice(3));
+  } catch {
+    compiled = null;
+  }
+  regexCache.set(entry, compiled);
+  return compiled;
+}
+
 function isOriginAllowed(origin: string, allowed: string[]): boolean {
   for (const entry of allowed) {
-    if (entry.startsWith("*")) {
-      const suffix = entry.slice(1); // e.g. "--openscan.netlify.app"
-      try {
-        const { hostname } = new URL(origin);
-        if (hostname.endsWith(suffix)) {
-          return true;
-        }
-      } catch {}
+    if (entry.startsWith("re:")) {
+      const re = compilePattern(entry);
+      if (re?.test(origin)) return true;
     } else if (origin === entry) {
       return true;
     }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -3,7 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2024-12-01"
 
 [vars]
-ALLOWED_ORIGINS = "https://openscan.eth.link,https://openscan.eth.limo,https://openscan-explorer.github.io,https://openscan.netlify.app,*--openscan.netlify.app"
+ALLOWED_ORIGINS = "https://openscan.eth.link,https://openscan.eth.limo,https://openscan-explorer.github.io,https://openscan.netlify.app,re:^https://(pr-\\d+|deploy-preview-\\d+)--openscan\\.netlify\\.app$"
 GROQ_MODEL = "groq/compound"
 
 # Secrets — set via `wrangler secret put <NAME>`


### PR DESCRIPTION
## Description

The worker's CORS allowlist used an unanchored suffix match (`*--openscan.netlify.app` → `hostname.endsWith("--openscan.netlify.app")`), which any Netlify tenant could satisfy by registering a site named `<anything>--openscan`. That site's origin would be approved by the worker and could proxy requests to the paid upstream APIs (Alchemy, Infura, Ankr, dRPC, OnFinality, Etherscan, Groq) using the maintainers' keys.

This PR replaces the glob syntax with anchored regex patterns (entries prefixed with `re:`) and restricts the Netlify allowance to the numeric PR/deploy-preview URL forms Netlify itself generates.

## Related Issue

Internal security review finding.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other

## Changes Made

- `worker/src/middleware/cors.ts`: replace `*`-prefix suffix matcher with anchored regex matcher (`re:` prefix). Invalid regex patterns are swallowed at compile time so they can't crash the middleware. Compiled patterns are cached.
- `worker/wrangler.toml`: swap `*--openscan.netlify.app` for `re:^https://(pr-\d+|deploy-preview-\d+)--openscan\.netlify\.app$`.
- `worker/README.md`: document the new `re:` syntax on `ALLOWED_ORIGINS`.

## Verification

Tested regex against legitimate and malicious origin shapes:

| Origin | Expected | Result |
|---|---|---|
| `https://deploy-preview-123--openscan.netlify.app` | allow | ✅ |
| `https://pr-95--openscan.netlify.app` | allow | ✅ |
| `https://attacker--openscan.netlify.app` | deny | ✅ |
| `https://deploy-preview-1--openscan--evil.netlify.app` | deny | ✅ |

Existing exact-match origins (`openscan.eth.link`, `openscan.eth.limo`, `openscan-explorer.github.io`, `openscan.netlify.app`) are unaffected.

## Residual risk (not addressed here)

An attacker could still register a Netlify site literally named `pr-1--openscan` to match the anchored regex. Fully closing that requires a shared secret injected only into trusted deployments; CORS alone is not a real authz boundary against cooperating attacker pages. Flagging as a follow-up.

## Vercel/Deno note

The Vercel and Deno entry points read `ALLOWED_ORIGINS` from their own env vars. Those deployments must have the env var updated to the new `re:` syntax when this is released.

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix`
- [x] I have run `npm run typecheck` with no errors
- [ ] I have run tests with `npm run test:run`
- [x] I have tested my changes locally (regex match matrix above)
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns