### PR TITLE
chore: bump version to 1.2.6-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "openscan",
-	"version": "1.2.5-alpha",
+	"version": "1.2.6-alpha",
 	"private": true,
 	"type": "module",
 	"packageManager": "bun@1.1.0",


### PR DESCRIPTION
## Description
Bump `package.json` version from `1.2.5-alpha` to `1.2.6-alpha` for the release tracked by #360.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring
- [ ] Performance improvement
- [x] Other: version bump

## Changes Made
- `package.json` `"version"`: `1.2.5-alpha` → `1.2.6-alpha`

## Checklist
- [x] I have run npm run format:fix and npm run lint:fix (no app changes)
- [x] I have run npm run typecheck with no errors
- [x] No code changed; nothing to test
- [x] I have tested my changes locally
- [x] My code follows the project's architecture patterns

## Additional Notes
- Mirrors the precedent set by #348 (`chore: bump version to 1.2.5-alpha`).
- Lands on `dev` so #360 (`dev → main`) carries the bump into main.
- `bun.lock` regenerated by `bun install` had no actual change (the `version` field is the project's own version, not a dep), so only `package.json` is in this commit.
