### PR TITLE
chore(dependabot): target dev branch for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   # updates the pinned SHA and the trailing `# vX` tag comment together.
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Description

Adds `target-branch: "dev"` to the github-actions dependabot config so future bumps land on `dev` (the patch release candidate) instead of `main`.

## Related Issue

N/A — process alignment with `.claude/rules/workflow.md`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [x] Other: CI / dependabot config

## Changes Made

- `.github/dependabot.yml`: set `target-branch: "dev"` for the `github-actions` ecosystem entry. The most recent batch (#372–#376) had to be retargeted by hand because dependabot defaulted to `main`; this prevents the same friction next week.

## Screenshots (if applicable)

N/A.

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix` (config-only change, no source files touched)
- [x] I have run `npm run typecheck` with no errors (no TS changes)
- [x] I have run tests with `npm run test:run` (no test-affecting changes)
- [x] I have tested my changes locally (yaml validates; one-line config addition)
- [x] I have updated documentation if needed (workflow rules already document dev-as-RC; this aligns config to the rule)
- [x] My code follows the project's architecture patterns

## Additional Notes

Doesn't affect the in-flight bump PRs (#372–#376) — those have already been retargeted manually. Effective from the next dependabot run.