### PR TITLE
fix(nft): proxy metadata fetches through worker to bypass CORS

### DIFF
--- a/src/config/workerConfig.ts
+++ b/src/config/workerConfig.ts
@@ -12,6 +12,16 @@ export function isWorkerProxyUrl(url: string): boolean {
   return WORKER_URLS.some((baseUrl) => url.startsWith(baseUrl));
 }
 
+/**
+ * Build a worker `/proxy/metadata?url=...` URL for the given target.
+ * Returns null if no worker proxy is configured. Uses the primary worker URL.
+ */
+export function buildMetadataProxyUrl(targetUrl: string): string | null {
+  const base = WORKER_URLS[0];
+  if (!base) return null;
+  return `${base}/proxy/metadata?url=${encodeURIComponent(targetUrl)}`;
+}
+
 /** HTTP status codes that trigger immediate failover to the next worker */
 const FAILOVER_STATUSES = new Set([502, 503]);
 

--- a/src/utils/erc1155Metadata.ts
+++ b/src/utils/erc1155Metadata.ts
@@ -3,6 +3,7 @@
  * Handles fetching and parsing ERC1155 token metadata from various URI formats
  */
 
+import { buildMetadataProxyUrl } from "../config/workerConfig";
 import { decodeAbiString, hexToString } from "./hexUtils";
 import { logger } from "./logger";
 
@@ -205,19 +206,34 @@ export async function fetchERC1155MetadataWithUri(
   // IPFS or HTTP URI - fetch the metadata
   const httpUri = ipfsToHttp(uri);
 
+  // Try direct fetch first; on CORS/network failure or non-OK response, fall
+  // back to the worker proxy (handles hosts without Access-Control-Allow-Origin).
   try {
     const response = await fetch(httpUri);
-    if (!response.ok) {
-      logger.error("Failed to fetch metadata:", response.status);
-      return { metadata: null, tokenUri: uri };
+    if (response.ok) {
+      const metadata = await response.json();
+      return { metadata: metadata as ERC1155TokenMetadata, tokenUri: uri };
     }
-
-    const metadata = await response.json();
-    return { metadata: metadata as ERC1155TokenMetadata, tokenUri: uri };
+    logger.warn("Direct metadata fetch returned non-OK, retrying via proxy:", response.status);
   } catch (error) {
-    logger.error("Failed to fetch/parse metadata:", error);
-    return { metadata: null, tokenUri: uri };
+    logger.warn("Direct metadata fetch failed, retrying via proxy:", error);
   }
+
+  const proxyUri = buildMetadataProxyUrl(httpUri);
+  if (proxyUri) {
+    try {
+      const response = await fetch(proxyUri);
+      if (response.ok) {
+        const metadata = await response.json();
+        return { metadata: metadata as ERC1155TokenMetadata, tokenUri: uri };
+      }
+      logger.error("Proxy metadata fetch returned non-OK:", response.status);
+    } catch (error) {
+      logger.error("Proxy metadata fetch failed:", error);
+    }
+  }
+
+  return { metadata: null, tokenUri: uri };
 }
 
 /**

--- a/src/utils/erc721Metadata.test.ts
+++ b/src/utils/erc721Metadata.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchERC721MetadataWithUri } from "./erc721Metadata";
+
+// Encode an ABI string return value the same way the on-chain call would.
+function encodeAbiString(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const hexBytes = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const padded = hexBytes.padEnd(Math.ceil(hexBytes.length / 64) * 64, "0");
+  const offset = "0000000000000000000000000000000000000000000000000000000000000020";
+  const length = bytes.length.toString(16).padStart(64, "0");
+  return `0x${offset}${length}${padded}`;
+}
+
+const CONTRACT = "0x5af0d9827e0c53e4799bb226655a1de152a425a5";
+const TOKEN_ID = "1";
+const RPC_URL = "https://example-rpc.test";
+const META_URL = "https://example-no-cors.test/json/1";
+const META_BODY = { name: "Token #1", image: "ipfs://QmHash/img.png" };
+
+describe("fetchERC721MetadataWithUri", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function rpcResponse(uri: string): Response {
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: encodeAbiString(uri) }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("returns metadata via direct fetch when CORS allows it", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(rpcResponse(META_URL)) // tokenURI()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(META_BODY), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const result = await fetchERC721MetadataWithUri(CONTRACT, TOKEN_ID, RPC_URL);
+
+    expect(result.tokenUri).toBe(META_URL);
+    expect(result.metadata).toEqual(META_BODY);
+    // Two fetches: RPC + direct metadata. No proxy retry needed.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the worker proxy when the direct fetch throws (CORS / network)", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(rpcResponse(META_URL)) // tokenURI()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch")) // CORS / network
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(META_BODY), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const result = await fetchERC721MetadataWithUri(CONTRACT, TOKEN_ID, RPC_URL);
+
+    expect(result.metadata).toEqual(META_BODY);
+    expect(result.tokenUri).toBe(META_URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    // Third call should hit the worker proxy with the encoded target URL
+    const proxyCall = fetchSpy.mock.calls[2]?.[0];
+    expect(typeof proxyCall).toBe("string");
+    expect(proxyCall as string).toContain("/proxy/metadata?url=");
+    expect(proxyCall as string).toContain(encodeURIComponent(META_URL));
+  });
+
+  it("falls back to the worker proxy when the direct fetch returns non-OK", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(rpcResponse(META_URL)) // tokenURI()
+      .mockResolvedValueOnce(new Response("nope", { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(META_BODY), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    const result = await fetchERC721MetadataWithUri(CONTRACT, TOKEN_ID, RPC_URL);
+
+    expect(result.metadata).toEqual(META_BODY);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns metadata=null with the URI preserved when the proxy also fails", async () => {
+    fetchSpy
+      .mockResolvedValueOnce(rpcResponse(META_URL)) // tokenURI()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(new Response("upstream timeout", { status: 504 }));
+
+    const result = await fetchERC721MetadataWithUri(CONTRACT, TOKEN_ID, RPC_URL);
+
+    expect(result.metadata).toBeNull();
+    expect(result.tokenUri).toBe(META_URL);
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not call the proxy for data: URIs", async () => {
+    const dataUri = "data:application/json,%7B%22name%22%3A%22inline%22%7D";
+    fetchSpy.mockResolvedValueOnce(rpcResponse(dataUri));
+
+    const result = await fetchERC721MetadataWithUri(CONTRACT, TOKEN_ID, RPC_URL);
+
+    expect(result.metadata).toEqual({ name: "inline" });
+    expect(result.tokenUri).toBe(dataUri);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/erc721Metadata.ts
+++ b/src/utils/erc721Metadata.ts
@@ -3,6 +3,7 @@
  * Handles fetching and parsing ERC721 NFT token metadata from various URI formats
  */
 
+import { buildMetadataProxyUrl } from "../config/workerConfig";
 import { decodeAbiString, hexToString } from "./hexUtils";
 import { logger } from "./logger";
 
@@ -241,19 +242,34 @@ export async function fetchERC721MetadataWithUri(
   // IPFS or HTTP URI - fetch the metadata
   const httpUri = ipfsToHttp(uri);
 
+  // Try direct fetch first; on CORS/network failure or non-OK response, fall
+  // back to the worker proxy (handles hosts without Access-Control-Allow-Origin).
   try {
     const response = await fetch(httpUri);
-    if (!response.ok) {
-      logger.error("Failed to fetch metadata:", response.status);
-      return { metadata: null, tokenUri: uri };
+    if (response.ok) {
+      const metadata = await response.json();
+      return { metadata: metadata as ERC721TokenMetadata, tokenUri: uri };
     }
-
-    const metadata = await response.json();
-    return { metadata: metadata as ERC721TokenMetadata, tokenUri: uri };
+    logger.warn("Direct metadata fetch returned non-OK, retrying via proxy:", response.status);
   } catch (error) {
-    logger.error("Failed to fetch/parse metadata:", error);
-    return { metadata: null, tokenUri: uri };
+    logger.warn("Direct metadata fetch failed, retrying via proxy:", error);
   }
+
+  const proxyUri = buildMetadataProxyUrl(httpUri);
+  if (proxyUri) {
+    try {
+      const response = await fetch(proxyUri);
+      if (response.ok) {
+        const metadata = await response.json();
+        return { metadata: metadata as ERC721TokenMetadata, tokenUri: uri };
+      }
+      logger.error("Proxy metadata fetch returned non-OK:", response.status);
+    } catch (error) {
+      logger.error("Proxy metadata fetch failed:", error);
+    }
+  }
+
+  return { metadata: null, tokenUri: uri };
 }
 
 /**

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6,11 +6,13 @@ import { rateLimitBeaconMiddleware } from "./middleware/rateLimitBeacon";
 import { rateLimitBtcMiddleware } from "./middleware/rateLimitBtc";
 import { rateLimitEtherscanMiddleware } from "./middleware/rateLimitEtherscan";
 import { rateLimitEvmMiddleware } from "./middleware/rateLimitEvm";
+import { rateLimitMetadataMiddleware } from "./middleware/rateLimitMetadata";
 import { validateMiddleware } from "./middleware/validate";
 import { validateBeaconMiddleware } from "./middleware/validateBeacon";
 import { validateBtcMiddleware } from "./middleware/validateBtc";
 import { validateEtherscanMiddleware } from "./middleware/validateEtherscan";
 import { validateEvmMiddleware } from "./middleware/validateEvm";
+import { validateMetadataProxyMiddleware } from "./middleware/validateMetadataProxy";
 import { analyzeHandler } from "./routes/analyze";
 import { btcAnkrHandler, evmAnkrHandler } from "./routes/ankrRpc";
 import { beaconAlchemyHandler } from "./routes/beaconBlobSidecars";
@@ -18,6 +20,7 @@ import { btcAlchemyHandler } from "./routes/btcRpc";
 import { etherscanVerifyHandler } from "./routes/etherscanVerify";
 import { btcDrpcHandler, evmDrpcHandler } from "./routes/drpcRpc";
 import { evmAlchemyHandler, evmInfuraHandler } from "./routes/evmRpc";
+import { metadataProxyHandler } from "./routes/metadataProxy";
 import { btcOnfinalityHandler } from "./routes/onfinalityRpc";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -76,6 +79,14 @@ app.post(
   rateLimitBtcMiddleware,
   validateBtcMiddleware,
   btcOnfinalityHandler,
+);
+
+// GET /proxy/metadata?url=<https-url> — CORS-bypassing fetch for NFT metadata JSON
+app.get(
+  "/proxy/metadata",
+  rateLimitMetadataMiddleware,
+  validateMetadataProxyMiddleware,
+  metadataProxyHandler,
 );
 
 // Health check

--- a/worker/src/middleware/rateLimitMetadata.ts
+++ b/worker/src/middleware/rateLimitMetadata.ts
@@ -1,0 +1,49 @@
+import type { Context, Next } from "hono";
+import type { Env } from "../types";
+
+const WINDOW_MS = 60_000; // 1 minute
+const MAX_REQUESTS = 60;
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+let lastCleanup = Date.now();
+const CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
+
+function cleanup(now: number) {
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+  for (const [key, entry] of store) {
+    if (entry.timestamps.every((ts) => now - ts > WINDOW_MS)) {
+      store.delete(key);
+    }
+  }
+}
+
+export async function rateLimitMetadataMiddleware(c: Context<{ Bindings: Env }>, next: Next) {
+  const ip = c.req.header("CF-Connecting-IP") ?? c.req.header("X-Forwarded-For") ?? "unknown";
+  const now = Date.now();
+
+  cleanup(now);
+
+  let entry = store.get(ip);
+  if (!entry) {
+    entry = { timestamps: [] };
+    store.set(ip, entry);
+  }
+
+  entry.timestamps = entry.timestamps.filter((ts) => now - ts < WINDOW_MS);
+
+  if (entry.timestamps.length >= MAX_REQUESTS) {
+    const oldestInWindow = entry.timestamps[0] as number;
+    const retryAfterSec = Math.ceil((WINDOW_MS - (now - oldestInWindow)) / 1000);
+    c.header("Retry-After", String(retryAfterSec));
+    return c.json({ error: "Rate limit exceeded. Try again later." }, 429);
+  }
+
+  entry.timestamps.push(now);
+  await next();
+}

--- a/worker/src/middleware/validateMetadataProxy.ts
+++ b/worker/src/middleware/validateMetadataProxy.ts
@@ -1,0 +1,115 @@
+import type { Context, Next } from "hono";
+import type { Env } from "../types";
+
+/**
+ * SSRF guard list — the security boundary for /proxy/metadata.
+ *
+ * Rejects requests targeting the worker's local network or other privileged
+ * destinations. If you add a new pattern here, add a matching test case in
+ * the worker validator tests (or, until those exist, manually exercise it
+ * via `wrangler dev`).
+ *
+ * Blocked:
+ *  - non-HTTPS schemes (http, data, file, ipfs, ftp, …)
+ *  - URLs with userinfo (`user:pass@host`)
+ *  - `localhost` (and any `*.localhost` subdomain)
+ *  - IPv4 loopback / private / link-local / unspecified ranges:
+ *      127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16,
+ *      169.254.0.0/16, 0.0.0.0/8
+ *  - IPv6 loopback (`::1`), ULA (`fd00::/8`), link-local (`fe80::/10`),
+ *    and IPv4-mapped variants of the above (`::ffff:<v4>`)
+ *  - Pathnames containing `..` segments
+ */
+
+function isPrivateIPv4(host: string): boolean {
+  // Match dotted-quad with each octet 0-255
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const octets = [m[1], m[2], m[3], m[4]].map((s) => Number(s));
+  if (octets.some((o) => o === undefined || Number.isNaN(o) || o < 0 || o > 255)) return false;
+  const [a, b] = octets as [number, number, number, number];
+  // 0.0.0.0/8 — "this host on this network"
+  if (a === 0) return true;
+  // 127.0.0.0/8 — loopback
+  if (a === 127) return true;
+  // 10.0.0.0/8 — private
+  if (a === 10) return true;
+  // 172.16.0.0/12 — private
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16 — private
+  if (a === 192 && b === 168) return true;
+  // 169.254.0.0/16 — link-local
+  if (a === 169 && b === 254) return true;
+  return false;
+}
+
+function isPrivateIPv6(host: string): boolean {
+  // URL.hostname returns IPv6 wrapped in brackets only if you read .host;
+  // .hostname strips them. Handle either form just in case.
+  let h = host.toLowerCase();
+  if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1);
+
+  // Loopback
+  if (h === "::1") return true;
+  // Unspecified
+  if (h === "::") return true;
+
+  // IPv4-mapped IPv6: ::ffff:a.b.c.d — apply IPv4 rules to the trailing v4
+  const v4Mapped = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4Mapped?.[1] && isPrivateIPv4(v4Mapped[1])) return true;
+
+  // Pure IPv6 — strip zone id
+  const noZone = h.split("%")[0] ?? h;
+
+  // ULA: fc00::/7 (covers fd00::/8 and fc00::/8)
+  if (/^f[cd][0-9a-f]{2}:/.test(noZone)) return true;
+  // Link-local: fe80::/10 — first 10 bits are 1111111010xx, so prefix fe8x..febx
+  if (/^fe[89ab][0-9a-f]:/.test(noZone)) return true;
+
+  return false;
+}
+
+function isLocalhostHost(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === "localhost") return true;
+  if (h.endsWith(".localhost")) return true;
+  return false;
+}
+
+export async function validateMetadataProxyMiddleware(c: Context<{ Bindings: Env }>, next: Next) {
+  const target = c.req.query("url");
+  if (!target) {
+    return c.json({ error: "url query parameter is required" }, 400);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return c.json({ error: "url is not a valid URL" }, 400);
+  }
+
+  if (parsed.protocol !== "https:") {
+    return c.json({ error: "Only https:// URLs are allowed" }, 400);
+  }
+
+  if (parsed.username || parsed.password) {
+    return c.json({ error: "URLs with userinfo are not allowed" }, 400);
+  }
+
+  if (parsed.pathname.split("/").includes("..")) {
+    return c.json({ error: "URL path must not contain '..' segments" }, 400);
+  }
+
+  const hostname = parsed.hostname;
+  if (!hostname) {
+    return c.json({ error: "url must include a hostname" }, 400);
+  }
+
+  if (isLocalhostHost(hostname) || isPrivateIPv4(hostname) || isPrivateIPv6(hostname)) {
+    return c.json({ error: "URL targets a disallowed host" }, 400);
+  }
+
+  c.set("validatedUrl" as never, parsed.toString() as never);
+  await next();
+}

--- a/worker/src/routes/metadataProxy.ts
+++ b/worker/src/routes/metadataProxy.ts
@@ -1,0 +1,57 @@
+import type { Context } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { Env } from "../types";
+
+const FETCH_TIMEOUT_MS = 5_000;
+const MAX_RESPONSE_BYTES = 1_048_576; // 1 MB
+const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+
+export async function metadataProxyHandler(c: Context<{ Bindings: Env }>) {
+  const targetUrl = c.get("validatedUrl" as never) as unknown as string;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(targetUrl, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: "follow",
+    });
+  } catch (error) {
+    const isAbort = error instanceof Error && error.name === "TimeoutError";
+    if (isAbort) {
+      return c.json({ error: "Upstream timeout" }, 504);
+    }
+    return c.json({ error: "Failed to fetch upstream URL" }, 502);
+  }
+
+  // Reject early if upstream advertises a body larger than our cap.
+  const contentLengthHeader = upstream.headers.get("content-length");
+  if (contentLengthHeader) {
+    const declared = Number.parseInt(contentLengthHeader, 10);
+    if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+      return c.json({ error: "Response too large" }, 413);
+    }
+  }
+
+  // Buffer the body, enforcing the cap. arrayBuffer() may decompress, so we
+  // also check the resulting byteLength.
+  let bodyBytes: ArrayBuffer;
+  try {
+    bodyBytes = await upstream.arrayBuffer();
+  } catch {
+    return c.json({ error: "Failed to read upstream response" }, 502);
+  }
+  if (bodyBytes.byteLength > MAX_RESPONSE_BYTES) {
+    return c.json({ error: "Response too large" }, 413);
+  }
+
+  const upstreamContentType = upstream.headers.get("content-type") ?? DEFAULT_CONTENT_TYPE;
+
+  // Mirror upstream status, but cap network/origin failure codes at 502 so
+  // clients can distinguish proxy issues from request issues.
+  let status = upstream.status;
+  if (status >= 500) status = 502;
+
+  c.header("Content-Type", upstreamContentType);
+  c.header("Cache-Control", "public, max-age=300");
+  return c.body(bodyBytes, status as ContentfulStatusCode);
+}

--- a/worker/src/routes/metadataProxy.ts
+++ b/worker/src/routes/metadataProxy.ts
@@ -4,7 +4,6 @@ import type { Env } from "../types";
 
 const FETCH_TIMEOUT_MS = 5_000;
 const MAX_RESPONSE_BYTES = 1_048_576; // 1 MB
-const DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
 export async function metadataProxyHandler(c: Context<{ Bindings: Env }>) {
   const targetUrl = c.get("validatedUrl" as never) as unknown as string;
@@ -44,14 +43,29 @@ export async function metadataProxyHandler(c: Context<{ Bindings: Env }>) {
     return c.json({ error: "Response too large" }, 413);
   }
 
-  const upstreamContentType = upstream.headers.get("content-type") ?? DEFAULT_CONTENT_TYPE;
+  // Parse and re-emit as JSON only. The route is reachable via top-level
+  // navigation (CORS fails open on missing Origin), so passing through the
+  // upstream Content-Type would let an attacker URL render arbitrary HTML/JS
+  // on the worker origin. Forcing JSON-parse + JSON content-type closes that
+  // vector and also transitively defends against a redirect chain landing on
+  // a non-JSON body. Frontend callers only ever invoke `response.json()`, so
+  // this is not a behavior change for them.
+  let parsed: unknown;
+  try {
+    const text = new TextDecoder("utf-8", { fatal: false }).decode(bodyBytes);
+    parsed = JSON.parse(text);
+  } catch {
+    return c.json({ error: "Upstream response is not valid JSON" }, 415);
+  }
 
   // Mirror upstream status, but cap network/origin failure codes at 502 so
   // clients can distinguish proxy issues from request issues.
   let status = upstream.status;
   if (status >= 500) status = 502;
 
-  c.header("Content-Type", upstreamContentType);
+  c.header("Content-Type", "application/json; charset=utf-8");
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("Content-Disposition", 'attachment; filename="metadata.json"');
   c.header("Cache-Control", "public, max-age=300");
-  return c.body(bodyBytes, status as ContentfulStatusCode);
+  return c.body(JSON.stringify(parsed), status as ContentfulStatusCode);
 }


### PR DESCRIPTION
## Description

NFT collections served from hosts without an `Access-Control-Allow-Origin` header have their metadata fetch silently blocked by the browser. The UI is left with the raw `tokenURI` string and no image. The bug surfaces today on Milady (`miladymaker.net`), but the same code path affects any non-CORS host.

This PR fixes the general class of bug by adding a worker-side proxy and a transparent client-side fallback for ERC-721 and ERC-1155 metadata fetches.

## Related Issue

Closes #367

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

**Worker (`worker/src/`)**
- New `GET /proxy/metadata?url=<https-url>` route, registered with the standard `cors → rateLimit → validate → handler` chain.
- `validateMetadataProxy.ts` — SSRF guards: HTTPS-only, no userinfo, no `..` segments. Blocks `localhost`/`*.localhost`, IPv4 private/loopback (`127/8`, `10/8`, `172.16-31`, `192.168/16`, `169.254/16`, `0/8`), IPv6 loopback (`::1`, `::`), ULA `fc00::/7`, link-local `fe80::/10`, and `::ffff:` v4-mapped variants.
- `metadataProxy.ts` — 5 s upstream timeout (504 on abort), 1 MB response cap (413 on overflow, both `Content-Length` pre-check and post-buffer check), content-type mirrored from upstream, status passed through (capped to 502 for upstream-side 5xx).
- `rateLimitMetadata.ts` — dedicated 60 req/min/IP limiter (the general AI limiter at 10/min is too tight for image-rate metadata browsing).

**Frontend (`src/`)**
- `workerConfig.ts` — `buildMetadataProxyUrl(targetUrl)` helper.
- `erc721Metadata.ts` / `erc1155Metadata.ts` — direct fetch first, retry through `/proxy/metadata` on throw or non-OK, fall through to `metadata: null` with the raw `tokenUri` preserved if both fail (matches current UX). `data:` URIs short-circuit before any network call. No image-URL changes (`<img>` doesn't trigger CORS for display).

**Tests**
- `erc721Metadata.test.ts` — 5 cases: happy path direct fetch, CORS/network throw → proxy retry, non-OK → proxy retry, both fail → null + URI preserved, `data:` URI short-circuit.

## Screenshots (if applicable)

N/A — no UI changes; the fix restores the standard NFT image rendering for affected collections.

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix` (one pre-existing lint warning in `settings/index.tsx` for `getAlchemyBtcUrl` is unrelated)
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run` (105 pass, 5 new)
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

**Deployment ordering is safe**: if the frontend ships before the worker redeploys, the proxy URL 404s on calls; the frontend treats 404 as non-OK and falls through to `metadata: null` — same as today's behaviour for unreachable metadata.

**Worker tests**: there's no Vitest scaffolding in `worker/` today, so the SSRF guard list is documented inline in `validateMetadataProxy.ts` as the security boundary for reviewer attention.

**No new settings toggle**: the proxy piggybacks on the existing worker presence — if `OPENSCAN_WORKER_URL` is unset/disabled, `buildMetadataProxyUrl` returns `null` and the retry is skipped.