### PR TITLE
feat(address): show native balances on other EVM mainnets

### DIFF
--- a/src/components/pages/evm/address/shared/AccountMoreInfoCard.tsx
+++ b/src/components/pages/evm/address/shared/AccountMoreInfoCard.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import type { ENSReverseResult } from "../../../../../types";
 import { useTranslation } from "react-i18next";
 import FieldLabel from "../../../../common/FieldLabel";
+import MultichainBalances from "./MultichainBalances";
 import TokenHoldings from "./TokenHoldings";
 
 interface AccountMoreInfoCardProps {
@@ -79,6 +80,12 @@ const AccountMoreInfoCard: React.FC<AccountMoreInfoCardProps> = ({
       {/* Token Holdings - Collapsible */}
       <div className="account-card-token-holdings">
         <TokenHoldings ownerAddress={ownerAddress} networkId={networkId} defaultCollapsed compact />
+        <MultichainBalances
+          address={ownerAddress}
+          currentChainId={networkId}
+          defaultCollapsed
+          compact
+        />
       </div>
     </div>
   );

--- a/src/components/pages/evm/address/shared/MultichainBalances.tsx
+++ b/src/components/pages/evm/address/shared/MultichainBalances.tsx
@@ -1,0 +1,219 @@
+import type React from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { getNetworkLogoUrlById } from "../../../../../config/networks";
+import { useMultichainBalances } from "../../../../../hooks/useMultichainBalances";
+import type { NetworkConfig } from "../../../../../types";
+import { getChainIdFromNetwork } from "../../../../../utils/networkResolver";
+import { formatNativeFromWei } from "../../../../../utils/unitFormatters";
+import OpenScanCubeLoader from "../../../../LoadingLogo";
+
+interface NetworkLogoProps {
+  src?: string;
+  name: string;
+  shortName: string;
+}
+
+const NetworkLogo: React.FC<NetworkLogoProps> = ({ src, name, shortName }) => {
+  const [hasError, setHasError] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: src is intentionally a dependency to reset error on URL change
+  useEffect(() => {
+    setHasError(false);
+  }, [src]);
+
+  if (hasError || !src) {
+    const letter = (shortName || name || "?").charAt(0).toUpperCase();
+    return (
+      <div className="token-logo token-logo-placeholder" title={name || shortName}>
+        {letter}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={name || shortName}
+      className="token-logo"
+      onError={() => setHasError(true)}
+    />
+  );
+};
+
+function getRouteSegment(network: NetworkConfig): string {
+  const chainId = getChainIdFromNetwork(network);
+  if (chainId !== undefined) return String(chainId);
+  if (network.slug) return network.slug;
+  return network.networkId;
+}
+
+function formatUsd(value: number | null): string | null {
+  if (value === null || value === undefined) return null;
+  if (value === 0) return "$0.00";
+  if (value >= 1000) {
+    return `$${value.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`;
+  }
+  if (value >= 0.01) return `$${value.toFixed(2)}`;
+  return "<$0.01";
+}
+
+interface MultichainBalancesProps {
+  address: string;
+  currentChainId: number;
+  defaultCollapsed?: boolean;
+  compact?: boolean;
+}
+
+const MultichainBalances: React.FC<MultichainBalancesProps> = ({
+  address,
+  currentChainId,
+  defaultCollapsed = false,
+  compact = false,
+}) => {
+  const { t } = useTranslation("address");
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+
+  const lowerAddress = useMemo(() => address.toLowerCase(), [address]);
+
+  const { rows, loading } = useMultichainBalances(lowerAddress, currentChainId);
+
+  const sortedRows = useMemo(() => {
+    const usdKnown = rows.filter((r) => r.usdValue !== null && r.usdValue !== undefined);
+    const usdUnknown = rows.filter((r) => r.usdValue === null || r.usdValue === undefined);
+
+    usdKnown.sort((a, b) => {
+      const diff = (b.usdValue ?? 0) - (a.usdValue ?? 0);
+      if (diff !== 0) return diff;
+      return a.network.name.localeCompare(b.network.name);
+    });
+
+    usdUnknown.sort((a, b) => {
+      const aBal = a.balance ? BigInt(a.balance) : 0n;
+      const bBal = b.balance ? BigInt(b.balance) : 0n;
+      if (aBal > bBal) return -1;
+      if (aBal < bBal) return 1;
+      return a.network.name.localeCompare(b.network.name);
+    });
+
+    return [...usdKnown, ...usdUnknown];
+  }, [rows]);
+
+  const nonZeroRows = useMemo(
+    () => rows.filter((r) => r.balance !== null && BigInt(r.balance) > 0n),
+    [rows],
+  );
+
+  // Hide the section entirely when the user has no other EVM mainnets enabled
+  // (e.g. OPENSCAN_NETWORKS=1) — there is nothing meaningful to show.
+  if (rows.length === 0) {
+    return null;
+  }
+
+  if (compact && isCollapsed) {
+    return (
+      <div className="token-holdings-compact">
+        <button
+          type="button"
+          className="token-holdings-toggle"
+          onClick={() => setIsCollapsed(false)}
+        >
+          <span className="token-holdings-toggle-label">{t("multichainBalances")}</span>
+          <span className="token-holdings-toggle-count">
+            {loading
+              ? t("loading")
+              : nonZeroRows.length === 0
+                ? t("noMultichainBalances")
+                : t("multichainNetworksCount", { count: nonZeroRows.length })}
+          </span>
+          <span className="token-holdings-toggle-arrow">+</span>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`tx-details token-holdings-section ${compact ? "token-holdings-compact-expanded" : ""}`}
+    >
+      <div className="tx-section">
+        <span className="tx-section-title">{t("multichainBalances")}</span>
+        {compact && (
+          <button
+            type="button"
+            className="token-holdings-collapse-btn"
+            onClick={() => setIsCollapsed(true)}
+          >
+            -
+          </button>
+        )}
+      </div>
+
+      {loading && rows.every((r) => r.loading) ? (
+        <div className="token-holdings-loading">
+          <OpenScanCubeLoader size={40} />
+          <span>{t("loadingMultichainBalances")}</span>
+        </div>
+      ) : nonZeroRows.length === 0 && !loading ? (
+        <div className="tx-row">
+          <span className="tx-value token-holdings-empty">{t("noMultichainBalances")}</span>
+        </div>
+      ) : (
+        <div className="token-holdings-list">
+          {sortedRows.map((row) => {
+            const formattedBalance =
+              row.balance !== null
+                ? formatNativeFromWei(row.balance, row.network.currency, 6)
+                : null;
+            const formattedUsd = formatUsd(row.usdValue);
+            const logoSrc = getNetworkLogoUrlById(row.chainId);
+            const segment = getRouteSegment(row.network);
+
+            return (
+              <Link
+                key={row.chainId}
+                to={`/${segment}/address/${lowerAddress}`}
+                className="token-holding-row"
+              >
+                <div className="token-holding-info">
+                  <NetworkLogo
+                    src={logoSrc}
+                    name={row.network.name}
+                    shortName={row.network.shortName}
+                  />
+                  <div className="token-holding-details">
+                    <span className="token-name">{row.network.shortName}</span>
+                    <span className="token-symbol">({row.network.currency})</span>
+                  </div>
+                </div>
+                <div className="token-holding-balance">
+                  {row.loading ? (
+                    <span className="account-card-loading">{t("loading")}</span>
+                  ) : row.error ? (
+                    <span
+                      className="account-card-empty"
+                      title={t("multichainBalanceErrorTooltip", { error: row.error })}
+                    >
+                      —
+                    </span>
+                  ) : (
+                    <>
+                      <span>{formattedBalance ?? `0 ${row.network.currency}`}</span>
+                      {formattedUsd && <span> · {formattedUsd}</span>}
+                    </>
+                  )}
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MultichainBalances;

--- a/src/components/pages/evm/address/shared/index.ts
+++ b/src/components/pages/evm/address/shared/index.ts
@@ -13,5 +13,6 @@ export { default as NFTCollectionInfoCard } from "./NFTCollectionInfoCard";
 export { default as ContractMoreInfoCard } from "./ContractMoreInfoCard";
 export { default as CustomTokenModal } from "./CustomTokenModal";
 export { default as ENSRecordsDisplay } from "./ENSRecordsDisplay";
+export { default as MultichainBalances } from "./MultichainBalances";
 export { default as TokenHoldings } from "./TokenHoldings";
 export { default as TransactionHistory } from "./TransactionHistory";

--- a/src/hooks/useMultichainBalances.ts
+++ b/src/hooks/useMultichainBalances.ts
@@ -1,0 +1,190 @@
+import { useContext, useEffect, useMemo, useReducer } from "react";
+import { AppContext } from "../context/AppContext";
+import { useSettings } from "../context/SettingsContext";
+import { getEnabledNetworks } from "../config/networks";
+import { DataService } from "../services/DataService";
+import { getNativeTokenPrice } from "../services/PriceService";
+import type { NetworkConfig, RpcUrlsContextType } from "../types";
+import { logger } from "../utils/logger";
+import { getChainIdFromNetwork } from "../utils/networkResolver";
+
+export interface MultichainBalanceRow {
+  chainId: number;
+  network: NetworkConfig;
+  balance: string | null;
+  usdValue: number | null;
+  loading: boolean;
+  error?: string;
+}
+
+type RowState = Map<number, MultichainBalanceRow>;
+
+type Action =
+  | { type: "init"; rows: MultichainBalanceRow[] }
+  | { type: "balance"; chainId: number; balance: string }
+  | { type: "balanceError"; chainId: number; error: string }
+  | { type: "price"; chainId: number; usdValue: number | null };
+
+function reducer(state: RowState, action: Action): RowState {
+  switch (action.type) {
+    case "init": {
+      const next = new Map<number, MultichainBalanceRow>();
+      for (const row of action.rows) next.set(row.chainId, row);
+      return next;
+    }
+    case "balance": {
+      const existing = state.get(action.chainId);
+      if (!existing) return state;
+      const next = new Map(state);
+      next.set(action.chainId, {
+        ...existing,
+        balance: action.balance,
+        loading: false,
+        error: undefined,
+      });
+      return next;
+    }
+    case "balanceError": {
+      const existing = state.get(action.chainId);
+      if (!existing) return state;
+      const next = new Map(state);
+      next.set(action.chainId, {
+        ...existing,
+        balance: null,
+        loading: false,
+        error: action.error,
+      });
+      return next;
+    }
+    case "price": {
+      const existing = state.get(action.chainId);
+      if (!existing) return state;
+      const next = new Map(state);
+      next.set(action.chainId, { ...existing, usdValue: action.usdValue });
+      return next;
+    }
+  }
+}
+
+// Mirrors the RPC-URL pickup pattern in AccountInfoCards.tsx so the two stay
+// in sync if the rpcUrls shape ever changes.
+function pickRpcUrl(rpcUrls: RpcUrlsContextType, chainId: number): string | undefined {
+  const entry = rpcUrls[`eip155:${chainId}`];
+  if (!entry) return undefined;
+  return Array.isArray(entry) ? entry[0] : entry;
+}
+
+export function useMultichainBalances(
+  address: string,
+  currentChainId: number,
+): { rows: MultichainBalanceRow[]; loading: boolean } {
+  const { rpcUrls, networksLoading } = useContext(AppContext);
+  const { settings } = useSettings();
+
+  // The network list is build-time stable (sourced from import.meta.env), so
+  // memoizing on currentChainId alone is sufficient. If OPENSCAN_NETWORKS ever
+  // becomes a runtime user setting, add the relevant dep here.
+  const targetNetworks = useMemo(() => {
+    return getEnabledNetworks().filter((n) => {
+      if (n.type !== "evm" || n.isTestnet) return false;
+      const chainId = getChainIdFromNetwork(n);
+      return chainId !== undefined && chainId !== currentChainId;
+    });
+  }, [currentChainId]);
+
+  const [state, dispatch] = useReducer(reducer, new Map<number, MultichainBalanceRow>());
+
+  // Initialize rows whenever the target list / address changes.
+  useEffect(() => {
+    const initial: MultichainBalanceRow[] = targetNetworks
+      .map((network) => {
+        const chainId = getChainIdFromNetwork(network);
+        if (chainId === undefined) return null;
+        const row: MultichainBalanceRow = {
+          chainId,
+          network,
+          balance: null,
+          usdValue: null,
+          loading: true,
+        };
+        return row;
+      })
+      .filter((r): r is MultichainBalanceRow => r !== null);
+    dispatch({ type: "init", rows: initial });
+  }, [targetNetworks]);
+
+  // Fetch balances per network. Stream each result independently. Re-runs when
+  // rpcUrls flips (e.g. after metadata refresh in AppContext) — intentional, do
+  // not remove rpcUrls from the deps or worker-proxy refresh will silently
+  // serve stale endpoints.
+  useEffect(() => {
+    if (networksLoading) return;
+    if (!address) return;
+    if (targetNetworks.length === 0) return;
+
+    let cancelled = false;
+    const lowered = address.toLowerCase();
+
+    for (const network of targetNetworks) {
+      const chainId = getChainIdFromNetwork(network);
+      if (chainId === undefined) continue;
+
+      (async () => {
+        try {
+          const service = new DataService(network, rpcUrls, settings.rpcStrategy);
+          const result = await service.networkAdapter.getAddress(lowered);
+          if (cancelled) return;
+          const balance = result?.data?.balance ?? "0";
+          dispatch({ type: "balance", chainId, balance });
+        } catch (err) {
+          if (cancelled) return;
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn(`Failed to fetch balance for chain ${chainId}:`, err);
+          dispatch({ type: "balanceError", chainId, error: message });
+        }
+      })();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [targetNetworks, rpcUrls, settings.rpcStrategy, address, networksLoading]);
+
+  // Fetch USD prices. Mirrors the pattern in AccountInfoCards.tsx — L2 ETH prices
+  // are derived from a mainnet RPC, so pass it through.
+  useEffect(() => {
+    if (networksLoading) return;
+    if (targetNetworks.length === 0) return;
+
+    let cancelled = false;
+    const mainnetRpcUrl = pickRpcUrl(rpcUrls, 1);
+
+    for (const network of targetNetworks) {
+      const chainId = getChainIdFromNetwork(network);
+      if (chainId === undefined) continue;
+      const rpcUrl = pickRpcUrl(rpcUrls, chainId);
+      if (!rpcUrl) continue;
+
+      (async () => {
+        try {
+          const price = await getNativeTokenPrice(chainId, rpcUrl, mainnetRpcUrl);
+          if (cancelled) return;
+          dispatch({ type: "price", chainId, usdValue: price });
+        } catch (err) {
+          if (cancelled) return;
+          logger.warn(`Failed to fetch native token price for chain ${chainId}:`, err);
+          dispatch({ type: "price", chainId, usdValue: null });
+        }
+      })();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [targetNetworks, rpcUrls, networksLoading]);
+
+  const rows = useMemo(() => Array.from(state.values()), [state]);
+  const loading = useMemo(() => rows.some((r) => r.loading), [rows]);
+
+  return { rows, loading };
+}

--- a/src/locales/en/address.json
+++ b/src/locales/en/address.json
@@ -221,5 +221,10 @@
   "facilitatorList": "List",
   "facilitatorYes": "Yes",
   "facilitatorNo": "No",
-  "facilitatorVisitWebsite": "Visit Website"
+  "facilitatorVisitWebsite": "Visit Website",
+  "multichainBalances": "Multichain Balances",
+  "loadingMultichainBalances": "Loading multichain balances...",
+  "multichainNetworksCount": "{{count}} networks",
+  "noMultichainBalances": "No balances on other networks",
+  "multichainBalanceErrorTooltip": "Could not fetch balance: {{error}}"
 }

--- a/src/locales/es/address.json
+++ b/src/locales/es/address.json
@@ -221,5 +221,10 @@
   "facilitatorList": "Listar",
   "facilitatorYes": "Sí",
   "facilitatorNo": "No",
-  "facilitatorVisitWebsite": "Visitar sitio web"
+  "facilitatorVisitWebsite": "Visitar sitio web",
+  "multichainBalances": "Saldos Multichain",
+  "loadingMultichainBalances": "Cargando saldos multichain...",
+  "multichainNetworksCount": "{{count}} redes",
+  "noMultichainBalances": "Sin saldo en otras redes",
+  "multichainBalanceErrorTooltip": "No se pudo obtener el saldo: {{error}}"
 }

--- a/src/locales/ja/address.json
+++ b/src/locales/ja/address.json
@@ -205,5 +205,10 @@
   "language": "言語",
   "optimizer": "オプティマイザ",
   "optimizerEnabled": "有効 ({{runs}} 回)",
-  "optimizerDisabled": "無効"
+  "optimizerDisabled": "無効",
+  "multichainBalances": "マルチチェーン残高",
+  "loadingMultichainBalances": "マルチチェーン残高を読み込み中...",
+  "multichainNetworksCount": "{{count}} ネットワーク",
+  "noMultichainBalances": "他のネットワークに残高はありません",
+  "multichainBalanceErrorTooltip": "残高を取得できませんでした: {{error}}"
 }

--- a/src/locales/pt-BR/address.json
+++ b/src/locales/pt-BR/address.json
@@ -205,5 +205,10 @@
   "language": "Linguagem",
   "optimizer": "Otimizador",
   "optimizerEnabled": "Ativado ({{runs}} execuções)",
-  "optimizerDisabled": "Desativado"
+  "optimizerDisabled": "Desativado",
+  "multichainBalances": "Saldos Multichain",
+  "loadingMultichainBalances": "Carregando saldos multichain...",
+  "multichainNetworksCount": "{{count}} redes",
+  "noMultichainBalances": "Sem saldo em outras redes",
+  "multichainBalanceErrorTooltip": "Não foi possível obter o saldo: {{error}}"
 }

--- a/src/locales/zh/address.json
+++ b/src/locales/zh/address.json
@@ -205,5 +205,10 @@
   "language": "语言",
   "optimizer": "优化器",
   "optimizerEnabled": "启用 ({{runs}} 次)",
-  "optimizerDisabled": "禁用"
+  "optimizerDisabled": "禁用",
+  "multichainBalances": "多链余额",
+  "loadingMultichainBalances": "加载多链余额中...",
+  "multichainNetworksCount": "{{count}} 个网络",
+  "noMultichainBalances": "其他网络上无余额",
+  "multichainBalanceErrorTooltip": "无法获取余额：{{error}}"
 }


### PR DESCRIPTION
## Description

Adds a "Multichain Balances" section under Token Holdings inside the More Info card on EVM address pages. The same address's native balance is fetched on every other enabled EVM mainnet in parallel, with USD value where pricing is available. Closes the common "is this address on other chains?" UX gap without leaving the explorer.

UX choices (locked in before implementation):
- **Scope**: EVM mainnets only — testnets and the currently-viewed network are excluded.
- **Timing**: Eager fetch on address-page mount so the dropdown is populated by the time the user expands it.
- **Zero balances**: shown explicitly so the user sees a complete picture; sorted by USD value desc, falling back to raw `BigInt(balance)` desc.

## Related Issue

N/A — direct user request.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- New hook `src/hooks/useMultichainBalances.ts`: instantiates `DataService` per target network (cannot use `useDataService` in a loop), fans out `getAddress` + `getNativeTokenPrice` with per-effect `cancelled` cleanup, streams results via `useReducer` so rows fill in as RPCs return rather than waiting for the slowest. The `rpcUrls` dep is intentional so worker-proxy refresh re-runs the fan-out — there is a code comment to that effect.
- New component `src/components/pages/evm/address/shared/MultichainBalances.tsx`: mirrors the `TokenHoldings` compact/collapsed UX exactly (same `token-holdings-*` and `token-holding-*` classes, same logo fallback pattern, same `defaultCollapsed compact` props), so no new CSS was needed. Hides itself when no other mainnets are configured (e.g. `OPENSCAN_NETWORKS=1`). Collapsed badge shows the empty-state copy when nothing has a balance, the network count otherwise.
- `AccountMoreInfoCard.tsx` renders `<MultichainBalances />` directly under `<TokenHoldings />` inside the `account-card-token-holdings` block.
- Translation keys added to all 5 locales (`en`, `es`, `ja`, `pt-BR`, `zh`): `multichainBalances`, `loadingMultichainBalances`, `multichainNetworksCount`, `noMultichainBalances`, `multichainBalanceErrorTooltip`. Flat keys to match the `tokenHoldings` convention.

## Screenshots (if applicable)

Manual smoke-tested locally on Ethereum mainnet against `0xd8dA…6045` (vitalik.eth) — section appears under Token Holdings, expands on click, rows populate within ~2 s, click-through navigates to the same address on the chosen network.

## Checklist

- [x] I have run `npm run format:fix` and `npm run lint:fix` (one pre-existing `getAlchemyBtcUrl` warning in `settings/index.tsx` is unrelated)
- [x] I have run `npm run typecheck` with no errors
- [x] I have run tests with `npm run test:run` (100 pass, no new tests — no precedent for hook unit tests in `src/hooks/`)
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's architecture patterns

## Additional Notes

**RPC cost**: each EVM address-page load now triggers ~6 mainnets × (`eth_getBalance` + native price) = ~12 extra RPC calls in addition to the existing `AccountOverviewCard` price fetch and `TokenHoldings` supporter-token batch. This is the intentional eager-fetch UX choice; if it becomes a problem on slower RPC tiers we can add a settings toggle.

**Code review**: ran an internal code review and addressed all recommended findings before this PR — `aliveRef` removed in favor of per-effect `cancelled` closures, `pickRpcUrl` simplified to mirror the canonical pattern in `AccountInfoCards.tsx`, address normalization unified between the Link target and the RPC fetch via a single `useMemo` lowercase, and explanatory comments added on the `rpcUrls` re-fanout and `targetNetworks` build-time-stable assumption.